### PR TITLE
feat: add PowerShell wrapper script to fix binary piping issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ setup(
     package_data={
         "proctap": ["bin/screencapture-audio"],  # Include ScreenCaptureKit Swift helper
     },
+    # Install PowerShell wrapper script to Scripts directory on Windows
+    scripts=["src/proctap/scripts/proctap.ps1"] if platform.system() == "Windows" else [],
     cmdclass={
         "build_py": BuildPyCommand,
     },

--- a/src/proctap/scripts/proctap.ps1
+++ b/src/proctap/scripts/proctap.ps1
@@ -1,0 +1,36 @@
+#!/usr/bin/env pwsh
+# PowerShell wrapper for proctap to handle binary streaming correctly
+# This script works around PowerShell's text encoding issues when piping binary data
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+# Start proctap.exe as a child process
+$process = New-Object System.Diagnostics.Process
+$process.StartInfo = New-Object System.Diagnostics.ProcessStartInfo
+
+$process.StartInfo.FileName = "proctap.exe"
+$process.StartInfo.Arguments = ($Args -join " ")
+
+# Redirect standard output to capture binary data
+$process.StartInfo.RedirectStandardOutput = $true
+$process.StartInfo.RedirectStandardError = $false
+$process.StartInfo.UseShellExecute = $false
+$process.StartInfo.CreateNoWindow = $true
+
+$process.Start() | Out-Null
+
+# Open PowerShell's stdout as binary stream
+$stdout = [Console]::OpenStandardOutput()
+$buffer = New-Object byte[] 8192
+
+# Stream binary data from proctap.exe to stdout
+while (($read = $process.StandardOutput.BaseStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+    $stdout.Write($buffer, 0, $read)
+    $stdout.Flush()
+}
+
+$process.WaitForExit() | Out-Null
+exit $process.ExitCode


### PR DESCRIPTION
PowerShell's default text encoding corrupts binary audio data when piping. This adds a PowerShell wrapper script that uses binary stream operations to properly handle raw PCM data when piping to tools like ffmpeg.

- Add proctap.ps1 wrapper script using [Console]::OpenStandardOutput()
- Update setup.py to install .ps1 script on Windows platforms
- PowerShell automatically prioritizes .ps1 over .exe, providing seamless usage
- Fixes audio corruption when using: proctap --stdout | ffmpeg ...