### PR TITLE
chore: add Dependabot config (github-actions + pip)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # GitHub Actions: keep workflow action references (actions/checkout,
+  # actions/setup-python, pypa/gh-action-pypi-publish, ...) up to date.
+  # Grouped so a single PR bumps the whole CI surface together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python dependencies declared in pyproject.toml ([project] + dev / contrib /
+  # hq-resample optional extras). Grouped so a normal weekly bump is one PR.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
## Summary

Enable Dependabot for two ecosystems on a **weekly Monday** schedule:

| Ecosystem | What it tracks |
|---|---|
| `github-actions` | every action used in `.github/workflows/` (checkout, setup-python, upload/download-artifact, pypa/gh-action-pypi-publish, ...) |
| `pip` | every package declared in `pyproject.toml` — `[project]` deps + `dev` / `contrib` / `hq-resample` / `docs` optional extras |

## Design choices

- **Grouped** so a normal weekly bump = **one PR per ecosystem**, not 10. Security advisories are intentionally **not grouped** (Dependabot's default) so they ship individually with the right priority.
- **`open-pull-requests-limit: 5`** per ecosystem — enough headroom for security PRs piling on top of the weekly group bump.
- **Commit prefixes**: `ci(...)` for actions, `deps(...)` for pip.
- **Labels** `dependencies` + `github-actions` / `python` to make filtering and triage easy.

## Test plan

- [ ] After merge, Dependabot's first scan should land within a few hours; expect 1 PR per ecosystem (or none if everything is current).
- [ ] Check the **Insights → Dependency graph → Dependabot** tab in the repo for any parser errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)