### PR TITLE
ci: drop Python 3.15 pre-release rows (scipy cp315 wheels not yet shipped)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,24 +25,14 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        experimental: [false]
-        # Track the Python 3.15 pre-release on every OS. allow-prereleases lets
-        # actions/setup-python pick up the latest alpha/beta/RC; experimental:
-        # true wires continue-on-error so a 3.15 regression does not break the
-        # required check while the 3.14 row still gates merges.
-        include:
-          - os: ubuntu-latest
-            python-version: "3.15"
-            experimental: true
-          - os: macos-latest
-            python-version: "3.15"
-            experimental: true
-          - os: windows-latest
-            python-version: "3.15"
-            experimental: true
+        # NOTE: Python 3.15 pre-release rows were removed in 2026-06.
+        # scipy does not yet ship cp315 wheels (alpha-stage), so
+        # `pip install -e ".[dev]"` falls back to a source build that
+        # needs gfortran on macOS / Windows and fails uniformly.
+        # Add 3.15 back once 3.15.0 ships (2026-10) and scipy publishes
+        # matching wheels.
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout repository
@@ -52,7 +42,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       # Linux: Install PulseAudio dependencies
       - name: Install PulseAudio (Linux)


### PR DESCRIPTION
## Why

The 3.15 experimental matrix added in #50 fails uniformly on all three OSes:

\`\`\`
../meson.build:88:0: ERROR: Unknown compiler(s):
  [['gfortran'], ['flang-new'], ['flang'], ['nvfortran'], ...]
\`\`\`

scipy has not shipped \`cp315\` wheels yet (3.15 is still alpha), so \`pip install -e \".[dev]\"\` falls back to a source build that needs Fortran — not present on GitHub-hosted macOS or Windows runners.

\`continue-on-error: true\` keeps the workflow status green, but the failed jobs still display as red ❌ on every PR. Pure noise, no signal: there is no scipy/cp315 combination to actually test against yet.

## What

- Remove the three \`include:\` rows for \`python-version: \"3.15\"\`
- Remove the matching \`experimental\` matrix axis, \`continue-on-error\`, and \`allow-prereleases\`
- Leave a comment in the matrix explaining when and how to re-enable: once **3.15.0 GA ships (2026-10)** and scipy publishes matching wheels, add the three rows back

The required 3.10–3.14 matrix is unchanged.

## Test plan

- [ ] CI on this PR shows the 3.10–3.14 grid only, no red 3.15 rows
- [ ] (Future) After 2026-10, verify scipy ships cp315 and re-add the rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)