### PR TITLE
refactor: readability & refactor cleanups (#25, #26, #29, #32, #34, #36)

### DIFF
--- a/src/proctap/backends/__init__.py
+++ b/src/proctap/backends/__init__.py
@@ -10,12 +10,12 @@ All backends return audio in standard format: 48kHz/2ch/float32
 from __future__ import annotations
 
 import platform
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
+
+from .base import ResampleQuality
 
 if TYPE_CHECKING:
     from .base import AudioBackend
-
-ResampleQuality = Literal['best', 'medium', 'fast']
 
 
 def get_backend(pid: int, resample_quality: ResampleQuality = 'best') -> "AudioBackend":

--- a/src/proctap/backends/base.py
+++ b/src/proctap/backends/base.py
@@ -75,7 +75,17 @@ class AudioBackend(ABC):
         Read audio data from the capture buffer.
 
         Returns:
-            PCM audio data as bytes, or None if no data is available
+            PCM audio data as bytes, or None if no data is available.
+
+        Sentinel convention (consistent across all backends):
+            - None            -> no usable data right now: nothing buffered, or a
+                                 chunk was logged-and-skipped after a recoverable
+                                 error (e.g. format conversion failed).
+            - non-empty bytes -> a real audio chunk in standard format.
+            - b'' is never returned to signal an error.
+
+        Unrecoverable errors should be raised as exceptions, not encoded in the
+        return value.
 
         Note:
             This method should not block for extended periods.

--- a/src/proctap/backends/base.py
+++ b/src/proctap/backends/base.py
@@ -12,7 +12,7 @@ All backends MUST convert audio to this standard format:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Literal, Optional
 import numpy as np
 
 
@@ -22,6 +22,10 @@ STANDARD_CHANNELS = 2
 STANDARD_FORMAT = 'float32'
 STANDARD_DTYPE = np.float32
 STANDARD_SAMPLE_WIDTH = 4  # bytes (32-bit float)
+
+# Canonical resample quality modes. Defined here (a dependency-free module that
+# every backend already imports) so all modules share a single source of truth.
+ResampleQuality = Literal['best', 'medium', 'fast']
 
 
 class AudioBackend(ABC):

--- a/src/proctap/backends/converter.py
+++ b/src/proctap/backends/converter.py
@@ -25,6 +25,28 @@ SAMPLERATE_CONVERTER_TYPES = {
     'fast': 'sinc_fastest',   # Lowest quality, fastest (~0.3-0.5ms estimated)
 }
 
+# --- PCM normalization constants -------------------------------------------
+# Divisors map full-scale signed integer PCM onto the normalized float range
+# [-1.0, 1.0]; each is 2^(bits-1).
+INT16_NORM_DIVISOR = 32768.0        # 2^15
+INT24_NORM_DIVISOR = 8388608.0      # 2^23
+INT32_NORM_DIVISOR = 2147483648.0   # 2^31
+# 24-bit samples stored in the upper 24 bits of an int32 container are 2^8 larger.
+INT24_32_CONTAINER_SCALE = 256.0    # 2^8
+
+# Peak magnitudes used when scaling a normalized float back to integer PCM. Using
+# the max positive value (2^(bits-1) - 1) keeps +1.0 from overflowing the range.
+INT16_PEAK = 32767.0                # 2^15 - 1
+INT24_PEAK = 8388607.0              # 2^23 - 1
+INT32_PEAK = 2147483647.0           # 2^31 - 1
+INT24_32_SHIFT = 256               # place a 24-bit value into the upper bits (int math)
+
+# --- Automatic format detection thresholds ---------------------------------
+FORMAT_DETECTION_MIN_SAMPLES = 100          # samples inspected for a reliable guess
+FORMAT_DETECTION_MIN_BYTES = 400            # need this many bytes (100 float32 samples)
+FORMAT_DETECTION_SIGNAL_THRESHOLD = 100     # int16 |amax| above this => real signal
+FLOAT32_DETECTION_MAX_ABS = 10.0            # plausible upper bound for float PCM |amax|
+
 try:
     from scipy import signal  # type: ignore[import-untyped]
     HAS_SCIPY = True
@@ -151,13 +173,13 @@ class AudioConverter:
         Returns:
             Detected format: SampleFormat.INT16 or SampleFormat.FLOAT32
         """
-        if len(pcm_bytes) < 400:  # Need at least 100 samples for reliable detection
+        if len(pcm_bytes) < FORMAT_DETECTION_MIN_BYTES:
             return self.src_format
 
         try:
             # First try 32-bit float interpretation (most common WASAPI mismatch)
             if len(pcm_bytes) % 4 == 0:
-                sample_count = min(len(pcm_bytes) // 4, 100)
+                sample_count = min(len(pcm_bytes) // 4, FORMAT_DETECTION_MIN_SAMPLES)
                 floats = np.frombuffer(pcm_bytes[:sample_count * 4], dtype=np.float32)
 
                 # Check for NaN/Inf
@@ -167,20 +189,20 @@ class AudioConverter:
                 if not has_nan and not has_inf:
                     max_abs = np.abs(floats).max()
 
-                    # Valid float32 audio is typically in [-1.0, 1.0] but allow up to 10.0
+                    # Valid float32 audio is typically in [-1.0, 1.0] but allow headroom.
                     # Reference: discord_source.py uses 0.0 < max_abs <= 10.0
-                    if 0.0 < max_abs <= 10.0:
+                    if 0.0 < max_abs <= FLOAT32_DETECTION_MAX_ABS:
                         logger.info(f"Auto-detected 32-bit float PCM format (max_abs={max_abs:.6f})")
                         return SampleFormat.FLOAT32
                 else:
                     logger.debug(f"Float32 interpretation invalid (nan={has_nan}, inf={has_inf})")
 
             # Try int16 interpretation
-            sample_count = min(len(pcm_bytes) // 2, 100)
+            sample_count = min(len(pcm_bytes) // 2, FORMAT_DETECTION_MIN_SAMPLES)
             int16_samples = np.frombuffer(pcm_bytes[:sample_count * 2], dtype=np.int16)
             int16_max = np.abs(int16_samples).max()
 
-            if int16_max > 100:  # Has significant signal (>100 to avoid false positives)
+            if int16_max > FORMAT_DETECTION_SIGNAL_THRESHOLD:  # significant signal
                 logger.info(f"Auto-detected 16-bit PCM format (max={int16_max})")
                 return SampleFormat.INT16
 
@@ -248,7 +270,7 @@ class AudioConverter:
         """
         if sample_format == SampleFormat.INT16:
             # 16-bit signed PCM
-            audio = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+            audio = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / INT16_NORM_DIVISOR
 
         elif sample_format == SampleFormat.INT24:
             # 24-bit signed PCM (3-byte packed) - OPTIMIZATION 1.3: Fully vectorized
@@ -267,17 +289,17 @@ class AudioConverter:
             # Use -16777216 (signed int32 equivalent of 0xFF000000) to avoid overflow
             audio_int32 = np.where(sign_bit != 0, audio_int32 | np.int32(-16777216), audio_int32)
             # Normalize to float32 in [-1.0, 1.0]
-            audio = audio_int32.astype(np.float32) / 8388608.0  # 2^23
+            audio = audio_int32.astype(np.float32) / INT24_NORM_DIVISOR
 
         elif sample_format == SampleFormat.INT24_32:
             # 24-bit in 32-bit container (upper 24 bits used)
             audio_int32 = np.frombuffer(pcm_bytes, dtype=np.int32)
             # Shift right 8 bits to get 24-bit value, then normalize
-            audio = (audio_int32.astype(np.float32) / 256.0) / 8388608.0  # divide by 2^8 then 2^23
+            audio = (audio_int32.astype(np.float32) / INT24_32_CONTAINER_SCALE) / INT24_NORM_DIVISOR
 
         elif sample_format == SampleFormat.INT32:
             # 32-bit signed PCM
-            audio = np.frombuffer(pcm_bytes, dtype=np.int32).astype(np.float32) / 2147483648.0  # 2^31
+            audio = np.frombuffer(pcm_bytes, dtype=np.int32).astype(np.float32) / INT32_NORM_DIVISOR
 
         elif sample_format == SampleFormat.FLOAT32:
             # 32-bit IEEE float (already normalized, typically)
@@ -321,12 +343,12 @@ class AudioConverter:
 
         if sample_format == SampleFormat.INT16:
             # 16-bit signed PCM
-            audio_int = (audio * 32767.0).astype(np.int16)
+            audio_int = (audio * INT16_PEAK).astype(np.int16)
             return cast(bytes, audio_int.tobytes())
 
         elif sample_format == SampleFormat.INT24:
             # 24-bit signed PCM (3-byte packed) - OPTIMIZATION 1.3: Fully vectorized
-            audio_int = (audio * 8388607.0).astype(np.int32)
+            audio_int = (audio * INT24_PEAK).astype(np.int32)
             # Extract 3 bytes from each int32 (little-endian) using vectorized indexing
             num_samples = len(audio_int)
             pcm_bytes = np.empty(num_samples * 3, dtype=np.uint8)
@@ -338,14 +360,14 @@ class AudioConverter:
 
         elif sample_format == SampleFormat.INT24_32:
             # 24-bit in 32-bit container (upper 24 bits)
-            audio_int24 = (audio * 8388607.0).astype(np.int32)
+            audio_int24 = (audio * INT24_PEAK).astype(np.int32)
             # Shift left 8 bits to place in upper 24 bits of 32-bit container
-            audio_int32 = (audio_int24 * 256).astype(np.int32)
+            audio_int32 = (audio_int24 * INT24_32_SHIFT).astype(np.int32)
             return cast(bytes, audio_int32.tobytes())
 
         elif sample_format == SampleFormat.INT32:
             # 32-bit signed PCM
-            audio_int = (audio * 2147483647.0).astype(np.int32)
+            audio_int = (audio * INT32_PEAK).astype(np.int32)
             return cast(bytes, audio_int.tobytes())
 
         elif sample_format == SampleFormat.FLOAT32:

--- a/src/proctap/backends/converter.py
+++ b/src/proctap/backends/converter.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 import numpy as np
 import logging
 import struct
-from typing import Optional, cast, Literal
+from typing import Optional, cast
+
+from .base import ResampleQuality
 
 logger = logging.getLogger(__name__)
-
-# Resample quality modes
-ResampleQuality = Literal['best', 'medium', 'fast']
 
 # libsamplerate converter type mapping
 SAMPLERATE_CONVERTER_TYPES = {

--- a/src/proctap/backends/linux.py
+++ b/src/proctap/backends/linux.py
@@ -105,6 +105,18 @@ class LinuxAudioStrategy(ABC):
     Allows switching between PulseAudio and PipeWire implementations.
     """
 
+    def __init__(
+        self, pid: int, sample_rate: int, channels: int, sample_width: int
+    ) -> None:
+        """
+        Every strategy is constructed with the target PID and capture format.
+
+        This only declares the shared constructor contract; concrete subclasses
+        override it and may supply their own sensible defaults for the format
+        arguments.
+        """
+        ...
+
     @abstractmethod
     def connect(self) -> None:
         """Connect to the audio server."""
@@ -994,83 +1006,10 @@ class LinuxBackend(AudioBackend):
                     "Could not detect audio server type, defaulting to PulseAudio"
                 )
 
-        # Select strategy based on detected/specified engine
-        if detected_engine == "pipewire-native":
-            # Try native PipeWire strategy first
-            try:
-                self._strategy: LinuxAudioStrategy = PipeWireNativeStrategy(
-                    pid=pid,
-                    sample_rate=sample_rate,
-                    channels=channels,
-                    sample_width=sample_width,
-                )
-                logger.info(
-                    f"Initialized LinuxBackend for PID {pid} "
-                    f"(engine: PipeWire Native API - ultra-low latency)"
-                )
-            except RuntimeError as e:
-                logger.warning(
-                    f"PipeWire native initialization failed, "
-                    f"falling back to subprocess: {e}"
-                )
-                # Fall back to subprocess-based PipeWire
-                try:
-                    self._strategy = PipeWireStrategy(
-                        pid=pid,
-                        sample_rate=sample_rate,
-                        channels=channels,
-                        sample_width=sample_width,
-                    )
-                    logger.info(
-                        f"Initialized LinuxBackend for PID {pid} (engine: PipeWire subprocess)"
-                    )
-                except RuntimeError as e2:
-                    logger.warning(f"PipeWire subprocess failed, falling back to PulseAudio: {e2}")
-                    self._strategy = PulseAudioStrategy(
-                        pid=pid,
-                        sample_rate=sample_rate,
-                        channels=channels,
-                        sample_width=sample_width,
-                    )
-                    logger.info(
-                        f"Initialized LinuxBackend for PID {pid} (engine: PulseAudio fallback)"
-                    )
-        elif detected_engine == "pulse":
-            self._strategy = PulseAudioStrategy(
-                pid=pid,
-                sample_rate=sample_rate,
-                channels=channels,
-                sample_width=sample_width,
-            )
-            logger.info(f"Initialized LinuxBackend for PID {pid} (engine: PulseAudio)")
-        elif detected_engine == "pipewire":
-            # Try PipeWire subprocess strategy, fall back to PulseAudio if it fails
-            try:
-                self._strategy = PipeWireStrategy(
-                    pid=pid,
-                    sample_rate=sample_rate,
-                    channels=channels,
-                    sample_width=sample_width,
-                )
-                logger.info(f"Initialized LinuxBackend for PID {pid} (engine: PipeWire subprocess)")
-            except RuntimeError as e:
-                logger.warning(
-                    f"PipeWire initialization failed, falling back to PulseAudio: {e}"
-                )
-                self._strategy = PulseAudioStrategy(
-                    pid=pid,
-                    sample_rate=sample_rate,
-                    channels=channels,
-                    sample_width=sample_width,
-                )
-                logger.info(
-                    f"Initialized LinuxBackend for PID {pid} (engine: PulseAudio fallback)"
-                )
-        else:
-            raise ValueError(
-                f"Unknown engine: {engine}. "
-                f"Use 'auto', 'pulse', 'pipewire', or 'pipewire-native'"
-            )
+        # Select strategy by walking the ordered fallback chain for this engine.
+        self._strategy: LinuxAudioStrategy = self._create_strategy(
+            detected_engine, pid, sample_rate, channels, sample_width
+        )
 
         # Setup audio format converter
         # Linux backends always capture as int16, so we need to convert to float32
@@ -1092,6 +1031,67 @@ class LinuxBackend(AudioBackend):
             f"{STANDARD_SAMPLE_RATE}Hz/{STANDARD_CHANNELS}ch/float32 "
             f"(quality={resample_quality})"
         )
+
+    def _get_strategy_chain(self, engine: str) -> list[type[LinuxAudioStrategy]]:
+        """
+        Return the ordered strategy classes to try for ``engine``.
+
+        Earlier entries are preferred; later entries are fallbacks used when an
+        earlier strategy cannot initialize on this system.
+
+        Raises:
+            ValueError: If ``engine`` is not a recognised value.
+        """
+        chains: dict[str, list[type[LinuxAudioStrategy]]] = {
+            "pipewire-native": [PipeWireNativeStrategy, PipeWireStrategy, PulseAudioStrategy],
+            "pipewire": [PipeWireStrategy, PulseAudioStrategy],
+            "pulse": [PulseAudioStrategy],
+        }
+        try:
+            return chains[engine]
+        except KeyError:
+            raise ValueError(
+                f"Unknown engine: {engine}. "
+                f"Use 'auto', 'pulse', 'pipewire', or 'pipewire-native'"
+            )
+
+    def _create_strategy(
+        self,
+        engine: str,
+        pid: int,
+        sample_rate: int,
+        channels: int,
+        sample_width: int,
+    ) -> LinuxAudioStrategy:
+        """
+        Instantiate the first strategy in the chain that initializes successfully.
+
+        Raises:
+            ValueError: If ``engine`` is unknown.
+            RuntimeError: If every strategy in the chain fails to initialize.
+        """
+        last_error: Optional[Exception] = None
+        for strategy_class in self._get_strategy_chain(engine):
+            try:
+                strategy = strategy_class(
+                    pid=pid,
+                    sample_rate=sample_rate,
+                    channels=channels,
+                    sample_width=sample_width,
+                )
+                logger.info(
+                    f"Initialized LinuxBackend for PID {pid} "
+                    f"(strategy: {strategy_class.__name__})"
+                )
+                return strategy
+            except RuntimeError as e:
+                last_error = e
+                logger.warning(f"{strategy_class.__name__} initialization failed: {e}")
+
+        raise RuntimeError(
+            f"No audio capture strategy could be initialized for engine '{engine}'. "
+            f"Last error: {last_error}"
+        ) from last_error
 
     def start(self) -> None:
         """

--- a/src/proctap/backends/linux.py
+++ b/src/proctap/backends/linux.py
@@ -1150,7 +1150,8 @@ class LinuxBackend(AudioBackend):
 
         Returns:
             PCM audio data as bytes in standard format (48kHz/2ch/float32),
-            or None if no data is available
+            or None if no data is available or the chunk could not be converted.
+            See AudioBackend.read for the shared sentinel convention.
         """
         if not self._is_running:
             return None
@@ -1162,8 +1163,9 @@ class LinuxBackend(AudioBackend):
             try:
                 data = self._converter.convert(data)
             except Exception as e:
+                # Recoverable: log and report "no usable data" (None), never b''.
                 logger.error(f"Error converting audio format: {e}")
-                return b''
+                return None
 
         return data
 

--- a/src/proctap/backends/linux.py
+++ b/src/proctap/backends/linux.py
@@ -162,30 +162,42 @@ class LinuxAudioStrategy(ABC):
         pass
 
 
-class PulseAudioStrategy(LinuxAudioStrategy):
+class _PulseCompatStrategy(LinuxAudioStrategy):
     """
-    PulseAudio-based audio capture strategy.
+    Shared base for strategies that drive capture through the PulseAudio API
+    (or PipeWire's PulseAudio compatibility layer) using ``pulsectl``.
 
-    Uses pulsectl library to interact with PulseAudio server.
-    Works on systems with PulseAudio or PipeWire (via pulseaudio-compat layer).
+    Both PulseAudio and PipeWire isolate a process by creating a temporary
+    null-sink, moving the target sink-input onto it and recording the null-sink's
+    monitor source. The only real differences between the two are cosmetic
+    (client name, sink names, log labels) and the external recorder invoked by
+    :meth:`_build_capture_command` (``parec`` vs ``pw-record``). Everything else
+    lives here so bug fixes apply to both backends at once.
+
+    Subclasses customise behaviour via the class attributes below and by
+    implementing :meth:`_build_capture_command`.
     """
 
-    def __init__(
-        self,
-        pid: int,
-        sample_rate: int = 44100,
-        channels: int = 2,
-        sample_width: int = 2,
+    # --- Subclass-provided identity / labels -------------------------------
+    _client_name: str = "proctap"
+    _server_short: str = "PulseAudio"
+    _connect_success_log: str = "Connected to PulseAudio server"
+    _connect_failure_prefix: str = "Failed to connect to PulseAudio server"
+    _connect_failure_hint: str = (
+        "Make sure PulseAudio or PipeWire (with pulseaudio-compat) is running."
+    )
+    _sink_name_prefix: str = "proctap_isolated"
+    _sink_description_prefix: str = "ProcTap_Isolated_PID"
+    _capture_error_label: str = "Failed to start audio capture"
+    _pulsectl_error_msg: str = (
+        "pulsectl library is required for Linux audio capture. "
+        "Install it with: pip install pulsectl"
+    )
+
+    def _init_common(
+        self, pid: int, sample_rate: int, channels: int, sample_width: int
     ) -> None:
-        """
-        Initialize PulseAudio strategy.
-
-        Args:
-            pid: Target process ID
-            sample_rate: Sample rate in Hz (default: 44100)
-            channels: Number of channels (default: 2 for stereo)
-            sample_width: Bytes per sample (default: 2 for 16-bit)
-        """
+        """Initialise the fields shared by every PulseAudio-compatible strategy."""
         self._pid = pid
         self._sample_rate = sample_rate
         self._channels = channels
@@ -193,45 +205,42 @@ class PulseAudioStrategy(LinuxAudioStrategy):
         self._bits_per_sample = sample_width * 8
 
         self._pulse: Any = None  # pulsectl.Pulse instance
+        self._pulsectl: Any = None  # pulsectl module
         self._sink_input_index: Optional[int] = None
+        self._stream_id: Optional[str] = None
         self._null_sink_index: Optional[int] = None
         self._null_sink_name: Optional[str] = None
         self._remap_source_index: Optional[int] = None
         self._remap_source_name: Optional[str] = None
         self._loopback_module_index: Optional[int] = None
         self._original_sink_index: Optional[int] = None
-        self._capture_stream = None
         self._audio_queue: queue.Queue[bytes] = queue.Queue(maxsize=50)  # ~500ms buffer
         self._capture_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._isolation_mode = "remap"  # "remap" or "monitor" (fallback)
         self._chunk_duration_ms = 10  # Configurable chunk duration in milliseconds
 
-        # Try to import pulsectl
-        self._pulsectl: Any = None  # pulsectl module
+    def _import_pulsectl(self) -> None:
+        """Import the pulsectl module, raising a helpful error if unavailable."""
         try:
             import pulsectl
             self._pulsectl = pulsectl
         except ImportError as e:
-            raise RuntimeError(
-                "pulsectl library is required for Linux audio capture. "
-                "Install it with: pip install pulsectl"
-            ) from e
+            raise RuntimeError(self._pulsectl_error_msg) from e
 
     def connect(self) -> None:
-        """Connect to PulseAudio server."""
+        """Connect to the audio server via the PulseAudio API."""
         try:
-            self._pulse = self._pulsectl.Pulse('proctap')
-            logger.info("Connected to PulseAudio server")
+            self._pulse = self._pulsectl.Pulse(self._client_name)
+            logger.info(self._connect_success_log)
         except Exception as e:
             raise RuntimeError(
-                f"Failed to connect to PulseAudio server: {e}. "
-                "Make sure PulseAudio or PipeWire (with pulseaudio-compat) is running."
+                f"{self._connect_failure_prefix}: {e}. {self._connect_failure_hint}"
             ) from e
 
     def find_process_stream(self, pid: int) -> bool:
         """
-        Find sink-input for the target process.
+        Find the sink-input for the target process.
 
         Args:
             pid: Process ID to find
@@ -240,10 +249,12 @@ class PulseAudioStrategy(LinuxAudioStrategy):
             True if stream found, False otherwise
 
         Raises:
-            RuntimeError: If not connected to PulseAudio
+            RuntimeError: If not connected
         """
         if self._pulse is None:
-            raise RuntimeError("Not connected to PulseAudio. Call connect() first.")
+            raise RuntimeError(
+                f"Not connected to {self._server_short}. Call connect() first."
+            )
 
         try:
             sink_inputs = self._pulse.sink_input_list()
@@ -254,6 +265,7 @@ class PulseAudioStrategy(LinuxAudioStrategy):
                 process_id_str = sink_input.proplist.get('application.process.id')
                 if process_id_str and process_id_str == str(pid):
                     self._sink_input_index = sink_input.index
+                    self._note_stream(sink_input)
                     logger.info(
                         f"Found sink-input #{sink_input.index} for PID {pid}: "
                         f"{sink_input.proplist.get('application.name', 'Unknown')}"
@@ -267,12 +279,15 @@ class PulseAudioStrategy(LinuxAudioStrategy):
             logger.error(f"Error finding process stream: {e}")
             return False
 
+    def _note_stream(self, sink_input: Any) -> None:
+        """Hook for subclasses to record extra stream metadata (no-op by default)."""
+
     def start_capture(self) -> None:
         """
         Start capturing audio from the target stream.
 
-        Uses module-remap-source to create an isolated audio source for the target
-        sink-input. Falls back to monitor source capture if isolation fails.
+        Creates an isolated capture using the null-sink strategy. Subclasses
+        decide what happens when isolation fails via :meth:`_handle_isolation_failure`.
 
         Raises:
             RuntimeError: If sink-input not found or capture fails to start
@@ -287,39 +302,49 @@ class PulseAudioStrategy(LinuxAudioStrategy):
             sink_input = self._pulse.sink_input_info(self._sink_input_index)
             self._original_sink_index = sink_input.sink
 
-            # Try to create isolated capture using module-remap-source
             try:
                 self._setup_isolated_capture()
                 logger.info(f"Using isolated capture mode for PID {self._pid}")
             except Exception as e:
-                logger.warning(
-                    f"Failed to setup isolated capture, falling back to monitor mode: {e}"
-                )
-                self._isolation_mode = "monitor"
-                self._setup_monitor_capture()
+                self._handle_isolation_failure(e)
 
         except Exception as e:
-            raise RuntimeError(f"Failed to start audio capture: {e}") from e
+            raise RuntimeError(f"{self._capture_error_label}: {e}") from e
+
+    def _handle_isolation_failure(self, exc: Exception) -> None:
+        """
+        Decide what to do when isolated capture setup fails.
+
+        The default re-raises (no fallback). PulseAudio overrides this to fall
+        back to whole-sink monitor capture.
+        """
+        raise exc
+
+    def _find_sink_by_name(self, sink_name: str) -> Any:
+        """Return the sink with the given name, or None if not present."""
+        for sink in self._pulse.sink_list():
+            if sink.name == sink_name:
+                return sink
+        return None
 
     def _setup_isolated_capture(self) -> None:
         """
-        Setup isolated audio capture using null-sink strategy.
+        Setup isolated audio capture using the null-sink strategy.
 
-        Strategy:
         1. Create a null-sink as a temporary destination
         2. Move the sink-input to the null-sink
         3. Get the null-sink's monitor source
-        4. Capture from the monitor source (which now has only our target app's audio)
-
-        This provides true per-process isolation.
+        4. Capture from the monitor source (now carrying only our target's audio)
         """
+        sink_name = f"{self._sink_name_prefix}_{self._pid}"
+        description = f"{self._sink_description_prefix}_{self._pid}"
+
         # Step 1: Create a null-sink
-        sink_name = f"proctap_isolated_{self._pid}"
         try:
             self._null_sink_index = self._pulse.module_load(
                 'module-null-sink',
                 args=f'sink_name={sink_name} '
-                     f'sink_properties=device.description="ProcTap_Isolated_PID_{self._pid}"'
+                     f'sink_properties=device.description="{description}"'
             )
             self._null_sink_name = sink_name
             logger.debug(f"Loaded null-sink: {sink_name} (index: {self._null_sink_index})")
@@ -328,18 +353,10 @@ class PulseAudioStrategy(LinuxAudioStrategy):
 
         # Step 2: Move sink-input to the null-sink
         try:
-            # Get the actual sink object by name
-            sinks = self._pulse.sink_list()
-            target_sink = None
-            for sink in sinks:
-                if sink.name == sink_name:
-                    target_sink = sink
-                    break
-
+            target_sink = self._find_sink_by_name(sink_name)
             if target_sink is None:
                 raise RuntimeError(f"Could not find created null-sink: {sink_name}")
 
-            # Move the sink-input
             self._pulse.sink_input_move(self._sink_input_index, target_sink.index)
             logger.debug(f"Moved sink-input #{self._sink_input_index} to null-sink #{target_sink.index}")
         except Exception as e:
@@ -349,17 +366,11 @@ class PulseAudioStrategy(LinuxAudioStrategy):
                     self._pulse.module_unload(self._null_sink_index)
                 except:
                     pass
-            raise RuntimeError(f"Failed to move sink-input to null-sink: {e}") from e
+            raise RuntimeError(f"Failed to move sink-input: {e}") from e
 
         # Step 3: Get the null-sink's monitor source
         try:
-            sinks = self._pulse.sink_list()
-            null_sink = None
-            for sink in sinks:
-                if sink.name == sink_name:
-                    null_sink = sink
-                    break
-
+            null_sink = self._find_sink_by_name(sink_name)
             if null_sink is None:
                 raise RuntimeError(f"Could not find null-sink after creation: {sink_name}")
 
@@ -370,7 +381,6 @@ class PulseAudioStrategy(LinuxAudioStrategy):
             raise RuntimeError(f"Failed to get monitor source: {e}") from e
 
         # Step 4: Start capture from the monitor source
-        # The monitor source now contains ONLY audio from our target process
         self._stop_event.clear()
         self._capture_thread = threading.Thread(
             target=self._capture_worker,
@@ -381,65 +391,16 @@ class PulseAudioStrategy(LinuxAudioStrategy):
 
         logger.info(f"Isolated audio capture started for PID {self._pid}")
 
-    def _setup_monitor_capture(self) -> None:
-        """
-        Setup fallback monitor source capture.
-
-        This captures from the entire sink monitor (not isolated).
-        Used when isolated capture fails.
-        """
-        if self._original_sink_index is None:
-            raise RuntimeError("Original sink index not set")
-
-        # Get monitor source name
-        sink_info = self._pulse.sink_info(self._original_sink_index)
-        monitor_source = sink_info.monitor_source_name
-
-        logger.info(
-            f"Using monitor capture from sink {self._original_sink_index} "
-            f"(monitor: {monitor_source})"
-        )
-        logger.warning(
-            "Monitor mode captures ALL audio from the sink, not just the target process. "
-            "This fallback is used when isolated capture fails."
-        )
-
-        # Start capture thread
-        self._stop_event.clear()
-        self._capture_thread = threading.Thread(
-            target=self._capture_worker,
-            args=(monitor_source,),
-            daemon=True
-        )
-        self._capture_thread.start()
-
-        logger.info("Monitor audio capture started")
-
     def _capture_worker(self, source_name: str) -> None:
         """
-        Worker thread that captures audio from PulseAudio.
+        Worker thread that records ``source_name`` into the audio queue.
 
-        Args:
-            source_name: Name of the source to capture from
+        The recorder command is backend-specific (:meth:`_build_capture_command`);
+        the read loop, chunking and back-pressure handling are shared.
         """
         try:
-            # Create a simple recorder using pulsectl
-            # Note: This is a simplified implementation
-            # For production, we'd need more sophisticated stream handling
-
-            import subprocess
-
-            # Use parec (PulseAudio recorder) to capture raw PCM
-            cmd = [
-                'parec',
-                '--device', source_name,
-                '--rate', str(self._sample_rate),
-                '--channels', str(self._channels),
-                '--format', 's16le',  # 16-bit signed little-endian
-                '--raw'
-            ]
-
-            logger.debug(f"Starting parec: {' '.join(cmd)}")
+            cmd = self._build_capture_command(source_name)
+            logger.debug(f"Starting capture: {' '.join(cmd)}")
 
             # Calculate chunk size for buffering
             chunk_frames = int(self._sample_rate * (self._chunk_duration_ms / 1000.0))
@@ -487,8 +448,12 @@ class PulseAudioStrategy(LinuxAudioStrategy):
         except Exception as e:
             logger.error(f"Capture worker error: {e}")
 
+    def _build_capture_command(self, source_name: str) -> list[str]:
+        """Return the recorder command line used to capture ``source_name``."""
+        raise NotImplementedError
+
     def _cleanup_isolation_modules(self) -> None:
-        """Clean up PulseAudio modules created for isolation."""
+        """Clean up modules created for isolation and restore audio routing."""
         if not self._pulse:
             return
 
@@ -541,13 +506,12 @@ class PulseAudioStrategy(LinuxAudioStrategy):
                 self._loopback_module_index = None
 
     def stop_capture(self) -> None:
-        """Stop capturing audio and clean up PulseAudio modules."""
+        """Stop capturing audio and clean up modules."""
         self._stop_event.set()
 
         if self._capture_thread and self._capture_thread.is_alive():
             self._capture_thread.join(timeout=2.0)
 
-        # Clean up isolation modules
         self._cleanup_isolation_modules()
 
         logger.info("Audio capture stopped")
@@ -574,7 +538,7 @@ class PulseAudioStrategy(LinuxAudioStrategy):
         if self._pulse:
             self._pulse.close()
             self._pulse = None
-            logger.debug("Closed PulseAudio connection")
+            logger.debug("Closed audio server connection")
 
     def get_format(self) -> dict[str, int | str]:
         """Get audio format information."""
@@ -585,7 +549,101 @@ class PulseAudioStrategy(LinuxAudioStrategy):
         }
 
 
-class PipeWireStrategy(LinuxAudioStrategy):
+class PulseAudioStrategy(_PulseCompatStrategy):
+    """
+    PulseAudio-based audio capture strategy.
+
+    Uses pulsectl library to interact with PulseAudio server.
+    Works on systems with PulseAudio or PipeWire (via pulseaudio-compat layer).
+    Captures the isolated monitor source with ``parec`` and, unlike PipeWire,
+    falls back to whole-sink monitor capture when isolation fails.
+    """
+
+    _client_name = "proctap"
+    _server_short = "PulseAudio"
+    _connect_success_log = "Connected to PulseAudio server"
+    _connect_failure_prefix = "Failed to connect to PulseAudio server"
+    _connect_failure_hint = (
+        "Make sure PulseAudio or PipeWire (with pulseaudio-compat) is running."
+    )
+    _sink_name_prefix = "proctap_isolated"
+    _sink_description_prefix = "ProcTap_Isolated_PID"
+    _capture_error_label = "Failed to start audio capture"
+
+    def __init__(
+        self,
+        pid: int,
+        sample_rate: int = 44100,
+        channels: int = 2,
+        sample_width: int = 2,
+    ) -> None:
+        """
+        Initialize PulseAudio strategy.
+
+        Args:
+            pid: Target process ID
+            sample_rate: Sample rate in Hz (default: 44100)
+            channels: Number of channels (default: 2 for stereo)
+            sample_width: Bytes per sample (default: 2 for 16-bit)
+        """
+        self._init_common(pid, sample_rate, channels, sample_width)
+        self._capture_stream = None
+        self._import_pulsectl()
+
+    def _build_capture_command(self, source_name: str) -> list[str]:
+        # Use parec (PulseAudio recorder) to capture raw PCM
+        return [
+            'parec',
+            '--device', source_name,
+            '--rate', str(self._sample_rate),
+            '--channels', str(self._channels),
+            '--format', 's16le',  # 16-bit signed little-endian
+            '--raw',
+        ]
+
+    def _handle_isolation_failure(self, exc: Exception) -> None:
+        logger.warning(
+            f"Failed to setup isolated capture, falling back to monitor mode: {exc}"
+        )
+        self._isolation_mode = "monitor"
+        self._setup_monitor_capture()
+
+    def _setup_monitor_capture(self) -> None:
+        """
+        Setup fallback monitor source capture.
+
+        This captures from the entire sink monitor (not isolated).
+        Used when isolated capture fails.
+        """
+        if self._original_sink_index is None:
+            raise RuntimeError("Original sink index not set")
+
+        # Get monitor source name
+        sink_info = self._pulse.sink_info(self._original_sink_index)
+        monitor_source = sink_info.monitor_source_name
+
+        logger.info(
+            f"Using monitor capture from sink {self._original_sink_index} "
+            f"(monitor: {monitor_source})"
+        )
+        logger.warning(
+            "Monitor mode captures ALL audio from the sink, not just the target process. "
+            "This fallback is used when isolated capture fails."
+        )
+
+        # Start capture thread
+        self._stop_event.clear()
+        self._capture_thread = threading.Thread(
+            target=self._capture_worker,
+            args=(monitor_source,),
+            daemon=True
+        )
+        self._capture_thread.start()
+
+        logger.info("Monitor audio capture started")
+
+
+class PipeWireStrategy(_PulseCompatStrategy):
     """
     PipeWire-based audio capture strategy using pw-record.
 
@@ -596,6 +654,19 @@ class PipeWireStrategy(LinuxAudioStrategy):
     Note: Falls back to PulseAudio compatibility layer (pulsectl)
     for stream enumeration and management.
     """
+
+    _client_name = "proctap-pipewire"
+    _server_short = "PipeWire"
+    _connect_success_log = "Connected to PipeWire (via PulseAudio compatibility layer)"
+    _connect_failure_prefix = "Failed to connect to PipeWire"
+    _connect_failure_hint = "Make sure PipeWire is running with PulseAudio compatibility."
+    _sink_name_prefix = "proctap_pw_isolated"
+    _sink_description_prefix = "ProcTap_PipeWire_PID"
+    _capture_error_label = "Failed to start PipeWire capture"
+    _pulsectl_error_msg = (
+        "pulsectl library is required for PipeWire stream management. "
+        "Install it with: pip install pulsectl"
+    )
 
     def __init__(
         self,
@@ -613,23 +684,7 @@ class PipeWireStrategy(LinuxAudioStrategy):
             channels: Number of channels (default: 2 for stereo)
             sample_width: Bytes per sample (default: 2 for 16-bit)
         """
-        self._pid = pid
-        self._sample_rate = sample_rate
-        self._channels = channels
-        self._sample_width = sample_width
-        self._bits_per_sample = sample_width * 8
-
-        self._pulse: Any = None  # pulsectl.Pulse instance (using PulseAudio compat layer)
-        self._sink_input_index: Optional[int] = None
-        self._stream_id: Optional[str] = None
-        self._null_sink_index: Optional[int] = None
-        self._null_sink_name: Optional[str] = None
-        self._original_sink_index: Optional[int] = None
-        self._audio_queue: queue.Queue[bytes] = queue.Queue(maxsize=50)  # ~500ms buffer
-        self._capture_thread: Optional[threading.Thread] = None
-        self._stop_event = threading.Event()
-        self._pulsectl: Any = None  # pulsectl module
-        self._chunk_duration_ms = 10  # Configurable chunk duration in milliseconds
+        self._init_common(pid, sample_rate, channels, sample_width)
 
         # Check if pw-record is available
         try:
@@ -647,276 +702,22 @@ class PipeWireStrategy(LinuxAudioStrategy):
             raise RuntimeError(f"Failed to check for pw-record: {e}") from e
 
         # Import pulsectl for stream management (PipeWire has PulseAudio compatibility)
-        try:
-            import pulsectl
-            self._pulsectl = pulsectl
-        except ImportError as e:
-            raise RuntimeError(
-                "pulsectl library is required for PipeWire stream management. "
-                "Install it with: pip install pulsectl"
-            ) from e
+        self._import_pulsectl()
 
-    def connect(self) -> None:
-        """Connect to PipeWire via PulseAudio compatibility layer."""
-        try:
-            self._pulse = self._pulsectl.Pulse('proctap-pipewire')
-            logger.info("Connected to PipeWire (via PulseAudio compatibility layer)")
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to connect to PipeWire: {e}. "
-                "Make sure PipeWire is running with PulseAudio compatibility."
-            ) from e
+    def _note_stream(self, sink_input: Any) -> None:
+        # PipeWire additionally exposes a native stream id we keep for diagnostics.
+        self._stream_id = sink_input.proplist.get('pipewire.stream.id')
 
-    def find_process_stream(self, pid: int) -> bool:
-        """
-        Find sink-input for the target process using PulseAudio compatibility API.
-
-        Args:
-            pid: Process ID to find
-
-        Returns:
-            True if stream found, False otherwise
-        """
-        if self._pulse is None:
-            raise RuntimeError("Not connected to PipeWire. Call connect() first.")
-
-        try:
-            sink_inputs = self._pulse.sink_input_list()
-            logger.debug(f"Found {len(sink_inputs)} sink inputs")
-
-            for sink_input in sink_inputs:
-                # Check application.process.id property
-                process_id_str = sink_input.proplist.get('application.process.id')
-                if process_id_str and process_id_str == str(pid):
-                    self._sink_input_index = sink_input.index
-                    # Try to get PipeWire stream ID
-                    self._stream_id = sink_input.proplist.get('pipewire.stream.id')
-                    logger.info(
-                        f"Found sink-input #{sink_input.index} for PID {pid}: "
-                        f"{sink_input.proplist.get('application.name', 'Unknown')}"
-                        f" (PW stream ID: {self._stream_id})"
-                    )
-                    return True
-
-            logger.warning(f"No audio stream found for PID {pid}")
-            return False
-
-        except Exception as e:
-            logger.error(f"Error finding process stream: {e}")
-            return False
-
-    def start_capture(self) -> None:
-        """
-        Start capturing audio using PipeWire.
-
-        Uses null-sink strategy similar to PulseAudio for isolation.
-        """
-        if self._sink_input_index is None:
-            raise RuntimeError("No sink-input found. Call find_process_stream() first.")
-
-        try:
-            # Get sink-input details
-            sink_input = self._pulse.sink_input_info(self._sink_input_index)
-            self._original_sink_index = sink_input.sink
-
-            # Use null-sink strategy for isolation
-            self._setup_isolated_capture()
-            logger.info(f"PipeWire isolated capture started for PID {self._pid}")
-
-        except Exception as e:
-            raise RuntimeError(f"Failed to start PipeWire capture: {e}") from e
-
-    def _setup_isolated_capture(self) -> None:
-        """Setup isolated capture using null-sink (same as PulseAudio strategy)."""
-        # Create null-sink
-        sink_name = f"proctap_pw_isolated_{self._pid}"
-        try:
-            self._null_sink_index = self._pulse.module_load(
-                'module-null-sink',
-                args=f'sink_name={sink_name} '
-                     f'sink_properties=device.description="ProcTap_PipeWire_PID_{self._pid}"'
-            )
-            self._null_sink_name = sink_name
-            logger.debug(f"Loaded null-sink: {sink_name} (index: {self._null_sink_index})")
-        except Exception as e:
-            raise RuntimeError(f"Failed to load null-sink: {e}") from e
-
-        # Move sink-input to null-sink
-        try:
-            sinks = self._pulse.sink_list()
-            target_sink = None
-            for sink in sinks:
-                if sink.name == sink_name:
-                    target_sink = sink
-                    break
-
-            if target_sink is None:
-                raise RuntimeError(f"Could not find created null-sink: {sink_name}")
-
-            self._pulse.sink_input_move(self._sink_input_index, target_sink.index)
-            logger.debug(f"Moved sink-input #{self._sink_input_index} to null-sink #{target_sink.index}")
-        except Exception as e:
-            if self._null_sink_index is not None:
-                try:
-                    self._pulse.module_unload(self._null_sink_index)
-                except:
-                    pass
-            raise RuntimeError(f"Failed to move sink-input: {e}") from e
-
-        # Get monitor source
-        try:
-            sinks = self._pulse.sink_list()
-            null_sink = None
-            for sink in sinks:
-                if sink.name == sink_name:
-                    null_sink = sink
-                    break
-
-            if null_sink is None:
-                raise RuntimeError(f"Could not find null-sink: {sink_name}")
-
-            monitor_source_name = null_sink.monitor_source_name
-            logger.debug(f"Monitor source: {monitor_source_name}")
-        except Exception as e:
-            self._cleanup_isolation_modules()
-            raise RuntimeError(f"Failed to get monitor source: {e}") from e
-
-        # Start capture using pw-record
-        self._stop_event.clear()
-        self._capture_thread = threading.Thread(
-            target=self._capture_worker_pwrecord,
-            args=(monitor_source_name,),
-            daemon=True
-        )
-        self._capture_thread.start()
-
-    def _capture_worker_pwrecord(self, source_name: str) -> None:
-        """
-        Worker thread using pw-record for PipeWire-native capture.
-
-        Args:
-            source_name: Name of the source to capture from
-        """
-        try:
-            # Build pw-record command
-            # Note: pw-record uses different argument format than parec
-            cmd = [
-                'pw-record',
-                '--target', source_name,
-                '--rate', str(self._sample_rate),
-                '--channels', str(self._channels),
-                '--format', 's16',  # 16-bit signed
-                '-',  # Output to stdout
-            ]
-
-            logger.debug(f"Starting pw-record: {' '.join(cmd)}")
-
-            # Calculate chunk size for buffering
-            chunk_frames = int(self._sample_rate * (self._chunk_duration_ms / 1000.0))
-            chunk_bytes = chunk_frames * self._channels * self._sample_width
-
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=chunk_bytes,  # Buffer one chunk to reduce system calls
-            )
-
-            while not self._stop_event.is_set():
-                try:
-                    if proc.stdout is None:
-                        break
-                    chunk = proc.stdout.read(chunk_bytes)
-                    if not chunk:
-                        break
-
-                    if len(chunk) == chunk_bytes:
-                        try:
-                            self._audio_queue.put_nowait(chunk)
-                        except queue.Full:
-                            # Drop old frames
-                            try:
-                                self._audio_queue.get_nowait()
-                                self._audio_queue.put_nowait(chunk)
-                            except:
-                                pass
-
-                except Exception as e:
-                    logger.error(f"Error reading audio: {e}")
-                    break
-
-            # Clean up
-            proc.terminate()
-            try:
-                proc.wait(timeout=1.0)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-
-            logger.debug("PipeWire capture worker stopped")
-
-        except Exception as e:
-            logger.error(f"PipeWire capture worker error: {e}")
-
-    def stop_capture(self) -> None:
-        """Stop capturing audio and clean up."""
-        self._stop_event.set()
-
-        if self._capture_thread and self._capture_thread.is_alive():
-            self._capture_thread.join(timeout=2.0)
-
-        self._cleanup_isolation_modules()
-        logger.info("PipeWire audio capture stopped")
-
-    def _cleanup_isolation_modules(self) -> None:
-        """Clean up PipeWire/PulseAudio modules."""
-        if not self._pulse:
-            return
-
-        # Restore sink-input
-        if (self._sink_input_index is not None and
-            self._original_sink_index is not None):
-            try:
-                sink_input = self._pulse.sink_input_info(self._sink_input_index)
-                if sink_input:
-                    self._pulse.sink_input_move(self._sink_input_index, self._original_sink_index)
-                    logger.debug(f"Restored sink-input to original sink")
-            except Exception as e:
-                logger.debug(f"Could not restore sink-input: {e}")
-
-        # Unload null-sink
-        if self._null_sink_index is not None:
-            try:
-                self._pulse.module_unload(self._null_sink_index)
-                logger.debug(f"Unloaded null-sink module")
-            except Exception as e:
-                logger.warning(f"Failed to unload null-sink: {e}")
-            finally:
-                self._null_sink_index = None
-                self._null_sink_name = None
-
-    def read_audio(self, timeout: float = 0.1) -> Optional[bytes]:
-        """Read audio data from capture buffer."""
-        try:
-            return self._audio_queue.get(timeout=timeout)
-        except queue.Empty:
-            return None
-
-    def close(self) -> None:
-        """Clean up resources."""
-        self.stop_capture()
-
-        if self._pulse:
-            self._pulse.close()
-            self._pulse = None
-            logger.debug("Closed PipeWire connection")
-
-    def get_format(self) -> dict[str, int | str]:
-        """Get audio format information."""
-        return {
-            'sample_rate': self._sample_rate,
-            'channels': self._channels,
-            'bits_per_sample': self._bits_per_sample,
-        }
+    def _build_capture_command(self, source_name: str) -> list[str]:
+        # Note: pw-record uses a different argument format than parec
+        return [
+            'pw-record',
+            '--target', source_name,
+            '--rate', str(self._sample_rate),
+            '--channels', str(self._channels),
+            '--format', 's16',  # 16-bit signed
+            '-',  # Output to stdout
+        ]
 
 
 class PipeWireNativeStrategy(LinuxAudioStrategy):

--- a/src/proctap/backends/linux.py
+++ b/src/proctap/backends/linux.py
@@ -54,6 +54,10 @@ logger = logging.getLogger(__name__)
 # Type alias for audio callback
 AudioCallback = Callable[[bytes, int], None]
 
+# Capture buffering constants
+DEFAULT_QUEUE_DEPTH_FRAMES = 50   # queued chunks; ~500ms at 10ms chunks
+DEFAULT_CHUNK_DURATION_MS = 10    # duration of one captured/queued audio chunk
+
 
 def detect_audio_server() -> str:
     """
@@ -226,11 +230,13 @@ class _PulseCompatStrategy(LinuxAudioStrategy):
         self._remap_source_name: Optional[str] = None
         self._loopback_module_index: Optional[int] = None
         self._original_sink_index: Optional[int] = None
-        self._audio_queue: queue.Queue[bytes] = queue.Queue(maxsize=50)  # ~500ms buffer
+        self._audio_queue: queue.Queue[bytes] = queue.Queue(
+            maxsize=DEFAULT_QUEUE_DEPTH_FRAMES
+        )
         self._capture_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._isolation_mode = "remap"  # "remap" or "monitor" (fallback)
-        self._chunk_duration_ms = 10  # Configurable chunk duration in milliseconds
+        self._chunk_duration_ms = DEFAULT_CHUNK_DURATION_MS
 
     def _import_pulsectl(self) -> None:
         """Import the pulsectl module, raising a helpful error if unavailable."""

--- a/src/proctap/backends/linux.py
+++ b/src/proctap/backends/linux.py
@@ -382,8 +382,8 @@ class _PulseCompatStrategy(LinuxAudioStrategy):
             if self._null_sink_index is not None:
                 try:
                     self._pulse.module_unload(self._null_sink_index)
-                except:
-                    pass
+                except Exception as unload_err:
+                    logger.debug(f"Failed to unload null-sink during cleanup: {unload_err}")
             raise RuntimeError(f"Failed to move sink-input: {e}") from e
 
         # Step 3: Get the null-sink's monitor source
@@ -447,7 +447,8 @@ class _PulseCompatStrategy(LinuxAudioStrategy):
                             try:
                                 self._audio_queue.get_nowait()
                                 self._audio_queue.put_nowait(chunk)
-                            except:
+                            except Exception:
+                                # Best-effort drop; racing consumer emptied it, etc.
                                 pass
 
                 except Exception as e:
@@ -1194,7 +1195,9 @@ class LinuxBackend(AudioBackend):
         """Destructor to ensure cleanup."""
         try:
             self.close()
-        except:
+        except Exception:
+            # Suppress cleanup errors in the destructor, but let BaseException
+            # (e.g. KeyboardInterrupt, SystemExit) propagate.
             pass
 
 

--- a/src/proctap/backends/macos_pyobjc.py
+++ b/src/proctap/backends/macos_pyobjc.py
@@ -621,7 +621,8 @@ class MacOSNativeBackend(AudioBackend):
         """Destructor to ensure cleanup."""
         try:
             self.close()
-        except:
+        except Exception:
+            # Suppress cleanup errors; let BaseException (KeyboardInterrupt) pass.
             pass
 
     def _create_aggregate_device(self) -> int:

--- a/src/proctap/backends/pipewire_native.py
+++ b/src/proctap/backends/pipewire_native.py
@@ -1061,7 +1061,8 @@ class PipeWireNodeDiscovery:
         """Destructor."""
         try:
             self._cleanup()
-        except:
+        except Exception:
+            # Suppress cleanup errors; let BaseException (KeyboardInterrupt) pass.
             pass
 
 
@@ -1372,5 +1373,6 @@ class PipeWireStreamCapture:
         """Destructor."""
         try:
             self.stop()
-        except:
+        except Exception:
+            # Suppress cleanup errors; let BaseException (KeyboardInterrupt) pass.
             pass

--- a/src/proctap/backends/windows.py
+++ b/src/proctap/backends/windows.py
@@ -115,7 +115,8 @@ class WindowsBackend(AudioBackend):
 
         Returns:
             PCM audio data as bytes in standard format (48kHz/2ch/float32),
-            or empty bytes if no data available
+            or None if no data is available or the chunk could not be converted.
+            See AudioBackend.read for the shared sentinel convention.
         """
         data = self._native.read()
 
@@ -124,8 +125,9 @@ class WindowsBackend(AudioBackend):
             try:
                 data = self._converter.convert(data)
             except Exception as e:
+                # Recoverable: log and report "no usable data" (None), never b''.
                 logger.error(f"Error converting audio format: {e}")
-                return b''
+                return None
 
         return data
 

--- a/src/proctap/core.py
+++ b/src/proctap/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, AsyncIterator, Literal
+from typing import Callable, Optional, AsyncIterator
 import threading
 import queue
 import asyncio
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 from .backends import get_backend
 from .backends.base import (
     AudioBackend,
+    ResampleQuality,
     STANDARD_SAMPLE_RATE,
     STANDARD_CHANNELS,
     STANDARD_FORMAT,
@@ -23,9 +24,6 @@ from .backends.base import (
 )
 
 AudioCallback = Callable[[bytes, int], None]  # (pcm_bytes, num_frames)
-
-# Resample quality modes
-ResampleQuality = Literal['best', 'medium', 'fast']
 
 
 class ProcessAudioCapture:

--- a/tests/test_backend_error_handling.py
+++ b/tests/test_backend_error_handling.py
@@ -1,0 +1,89 @@
+"""
+Tests for Issue #32: consistent error-handling / sentinel convention across
+backends.
+
+Convention for ``AudioBackend.read()``:
+    - ``None``       -> no usable data right now (nothing available, or a chunk
+                        was logged-and-skipped because conversion failed)
+    - non-empty bytes -> a real audio chunk
+    - ``b''`` is never used to signal an error.
+
+Windows and Linux previously returned ``b''`` when format conversion raised,
+overloading the empty-bytes value. They must now return ``None`` consistently.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+class _RaisingConverter:
+    def convert(self, data):
+        raise ValueError("bad frame")
+
+
+@pytest.fixture
+def linux_mod():
+    import proctap.backends.linux as linux_mod
+    return linux_mod
+
+
+def _make_fake_strategy_cls():
+    class FakeStrategy:
+        def __init__(self, pid, sample_rate=44100, channels=2, sample_width=2):
+            pass
+    return FakeStrategy
+
+
+class TestLinuxReadErrorHandling:
+    def _backend(self, linux_mod, monkeypatch, read_value, converter):
+        monkeypatch.setattr(linux_mod, "PulseAudioStrategy", _make_fake_strategy_cls())
+        b = linux_mod.LinuxBackend(pid=1, engine="pulse")
+        b._is_running = True
+        b._strategy = SimpleNamespace(read_audio=lambda timeout=0.1: read_value)
+        b._converter = converter
+        return b
+
+    def test_conversion_error_returns_none(self, linux_mod, monkeypatch):
+        b = self._backend(linux_mod, monkeypatch, b"\x00\x00", _RaisingConverter())
+        assert b.read() is None
+
+    def test_successful_conversion_returns_data(self, linux_mod, monkeypatch):
+        conv = SimpleNamespace(convert=lambda data: b"converted")
+        b = self._backend(linux_mod, monkeypatch, b"\x00\x00", conv)
+        assert b.read() == b"converted"
+
+    def test_no_data_returns_none(self, linux_mod, monkeypatch):
+        conv = SimpleNamespace(convert=lambda data: b"x")
+        b = self._backend(linux_mod, monkeypatch, None, conv)
+        assert b.read() is None
+
+    def test_not_running_returns_none(self, linux_mod, monkeypatch):
+        b = self._backend(linux_mod, monkeypatch, b"\x00\x00", _RaisingConverter())
+        b._is_running = False
+        assert b.read() is None
+
+
+class TestWindowsReadErrorHandling:
+    def _backend(self, read_value, converter):
+        from proctap.backends.windows import WindowsBackend
+
+        b = WindowsBackend.__new__(WindowsBackend)
+        b._pid = 1
+        b._native = SimpleNamespace(read=lambda: read_value)
+        b._converter = converter
+        return b
+
+    def test_conversion_error_returns_none(self):
+        b = self._backend(b"\x00\x00", _RaisingConverter())
+        assert b.read() is None
+
+    def test_successful_conversion_returns_data(self):
+        b = self._backend(b"\x00\x00", SimpleNamespace(convert=lambda data: b"converted"))
+        assert b.read() == b"converted"
+
+    def test_no_data_returns_falsy(self):
+        # Native returns None when nothing is available; read() passes it through.
+        b = self._backend(None, SimpleNamespace(convert=lambda data: b"x"))
+        assert not b.read()

--- a/tests/test_converter_constants.py
+++ b/tests/test_converter_constants.py
@@ -1,0 +1,63 @@
+"""
+Tests for Issue #34: replace scattered magic numbers in the audio converter with
+named constants. These pin the constant values (guarding against typos) and lock
+the numeric conversion behaviour so the refactor cannot silently change output.
+"""
+
+import numpy as np
+import pytest
+
+from proctap.backends import converter as C
+from proctap.backends.converter import AudioConverter, SampleFormat
+
+
+class TestPcmConstants:
+    def test_normalization_divisors(self):
+        assert C.INT16_NORM_DIVISOR == 32768.0        # 2^15
+        assert C.INT24_NORM_DIVISOR == 8388608.0      # 2^23
+        assert C.INT32_NORM_DIVISOR == 2147483648.0   # 2^31
+
+    def test_peak_values(self):
+        assert C.INT16_PEAK == 32767.0                # 2^15 - 1
+        assert C.INT24_PEAK == 8388607.0              # 2^23 - 1
+        assert C.INT32_PEAK == 2147483647.0           # 2^31 - 1
+
+    def test_detection_thresholds(self):
+        assert C.FORMAT_DETECTION_MIN_SAMPLES == 100
+        assert C.FORMAT_DETECTION_MIN_BYTES == 400
+        assert C.FORMAT_DETECTION_SIGNAL_THRESHOLD == 100
+        assert C.FLOAT32_DETECTION_MAX_ABS == 10.0
+
+
+class TestConversionBehaviourUnchanged:
+    def _int16_to_float(self):
+        return AudioConverter(
+            src_rate=48000, src_channels=1, src_width=2,
+            dst_rate=48000, dst_channels=1, dst_width=4,
+            src_format=SampleFormat.INT16, dst_format=SampleFormat.FLOAT32,
+            auto_detect_format=False,
+        )
+
+    def _float_to_int16(self):
+        return AudioConverter(
+            src_rate=48000, src_channels=1, src_width=4,
+            dst_rate=48000, dst_channels=1, dst_width=2,
+            src_format=SampleFormat.FLOAT32, dst_format=SampleFormat.INT16,
+            auto_detect_format=False,
+        )
+
+    def test_int16_normalization(self):
+        conv = self._int16_to_float()
+        pcm = np.array([32767, -32768, 0], dtype=np.int16).tobytes()
+        out = np.frombuffer(conv.convert(pcm), dtype=np.float32)
+        assert out[2] == 0.0
+        assert out[0] == pytest.approx(32767 / 32768.0, abs=1e-6)
+        assert out[1] == pytest.approx(-1.0, abs=1e-6)
+
+    def test_float_to_int16_peak(self):
+        conv = self._float_to_int16()
+        pcm = np.array([1.0, -1.0, 0.0], dtype=np.float32).tobytes()
+        out = np.frombuffer(conv.convert(pcm), dtype=np.int16)
+        assert out[0] == 32767   # +1.0 scaled by INT16_PEAK, not 32768 (no overflow)
+        assert out[1] == -32767
+        assert out[2] == 0

--- a/tests/test_linux_backend.py
+++ b/tests/test_linux_backend.py
@@ -1,0 +1,151 @@
+"""
+Characterization tests for LinuxBackend engine/strategy selection (Issue #29).
+
+The deeply-nested try/except fallback chain in ``LinuxBackend.__init__`` is being
+flattened into a strategy-chain pattern. These tests pin down which strategy is
+chosen for every ``engine`` value and every fallback situation so the refactor
+provably preserves behaviour.
+
+Strategy classes are replaced with light fakes so no real PulseAudio / PipeWire
+is needed; the real ``AudioConverter`` (numpy) is exercised unchanged.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def linux_mod():
+    import proctap.backends.linux as linux_mod
+    return linux_mod
+
+
+def make_fake_strategy(label, fail=False):
+    """Build a stand-in strategy class tagged with ``label``."""
+
+    class FakeStrategy:
+        strategy_label = label
+        _should_fail = fail
+
+        def __init__(self, pid, sample_rate=44100, channels=2, sample_width=2):
+            if type(self)._should_fail:
+                raise RuntimeError(f"{label} unavailable")
+            self.pid = pid
+            self.sample_rate = sample_rate
+            self.channels = channels
+            self.sample_width = sample_width
+
+    FakeStrategy.__name__ = f"Fake{label}Strategy"
+    return FakeStrategy
+
+
+@pytest.fixture
+def patch_strategies(monkeypatch, linux_mod):
+    """Replace the three strategy classes; return a helper to configure failures."""
+
+    def configure(native=False, pipewire=False, pulse=False):
+        monkeypatch.setattr(
+            linux_mod, "PipeWireNativeStrategy",
+            make_fake_strategy("native", fail=native),
+        )
+        monkeypatch.setattr(
+            linux_mod, "PipeWireStrategy",
+            make_fake_strategy("pipewire", fail=pipewire),
+        )
+        monkeypatch.setattr(
+            linux_mod, "PulseAudioStrategy",
+            make_fake_strategy("pulse", fail=pulse),
+        )
+
+    return configure
+
+
+def _label(backend):
+    return backend._strategy.strategy_label
+
+
+class TestExplicitEngine:
+    def test_pulse(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pulse")
+        assert _label(b) == "pulse"
+
+    def test_pipewire(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pipewire")
+        assert _label(b) == "pipewire"
+
+    def test_pipewire_native(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pipewire-native")
+        assert _label(b) == "native"
+
+    def test_unknown_engine_raises(self, linux_mod, patch_strategies):
+        patch_strategies()
+        with pytest.raises(ValueError, match="Unknown engine"):
+            linux_mod.LinuxBackend(pid=1, engine="bogus")
+
+
+class TestFallbackChains:
+    def test_pipewire_falls_back_to_pulse(self, linux_mod, patch_strategies):
+        patch_strategies(pipewire=True)
+        b = linux_mod.LinuxBackend(pid=1, engine="pipewire")
+        assert _label(b) == "pulse"
+
+    def test_native_falls_back_to_pipewire(self, linux_mod, patch_strategies):
+        patch_strategies(native=True)
+        b = linux_mod.LinuxBackend(pid=1, engine="pipewire-native")
+        assert _label(b) == "pipewire"
+
+    def test_native_falls_back_through_to_pulse(self, linux_mod, patch_strategies):
+        patch_strategies(native=True, pipewire=True)
+        b = linux_mod.LinuxBackend(pid=1, engine="pipewire-native")
+        assert _label(b) == "pulse"
+
+    def test_pulse_only_has_no_fallback(self, linux_mod, patch_strategies):
+        patch_strategies(pulse=True)
+        with pytest.raises(RuntimeError):
+            linux_mod.LinuxBackend(pid=1, engine="pulse")
+
+    def test_all_fail_raises_runtime_error(self, linux_mod, patch_strategies):
+        patch_strategies(native=True, pipewire=True, pulse=True)
+        with pytest.raises(RuntimeError):
+            linux_mod.LinuxBackend(pid=1, engine="pipewire-native")
+
+
+class TestAutoDetect:
+    def test_auto_pipewire_with_native(self, linux_mod, patch_strategies, monkeypatch):
+        patch_strategies()
+        monkeypatch.setattr(linux_mod, "detect_audio_server", lambda: "pipewire")
+        monkeypatch.setattr(linux_mod, "PIPEWIRE_NATIVE_AVAILABLE", True)
+        b = linux_mod.LinuxBackend(pid=1, engine="auto")
+        assert _label(b) == "native"
+
+    def test_auto_pipewire_without_native(self, linux_mod, patch_strategies, monkeypatch):
+        patch_strategies()
+        monkeypatch.setattr(linux_mod, "detect_audio_server", lambda: "pipewire")
+        monkeypatch.setattr(linux_mod, "PIPEWIRE_NATIVE_AVAILABLE", False)
+        b = linux_mod.LinuxBackend(pid=1, engine="auto")
+        assert _label(b) == "pipewire"
+
+    def test_auto_pulseaudio(self, linux_mod, patch_strategies, monkeypatch):
+        patch_strategies()
+        monkeypatch.setattr(linux_mod, "detect_audio_server", lambda: "pulseaudio")
+        b = linux_mod.LinuxBackend(pid=1, engine="auto")
+        assert _label(b) == "pulse"
+
+    def test_auto_unknown_defaults_to_pulse(self, linux_mod, patch_strategies, monkeypatch):
+        patch_strategies()
+        monkeypatch.setattr(linux_mod, "detect_audio_server", lambda: "unknown")
+        b = linux_mod.LinuxBackend(pid=1, engine="auto")
+        assert _label(b) == "pulse"
+
+
+class TestBackendFormat:
+    def test_get_format_is_standard(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pulse")
+        fmt = b.get_format()
+        assert fmt["sample_rate"] == 48000
+        assert fmt["channels"] == 2
+        assert fmt["bits_per_sample"] == 32
+        assert fmt["sample_format"] == "float32"

--- a/tests/test_linux_backend.py
+++ b/tests/test_linux_backend.py
@@ -149,3 +149,26 @@ class TestBackendFormat:
         assert fmt["channels"] == 2
         assert fmt["bits_per_sample"] == 32
         assert fmt["sample_format"] == "float32"
+
+
+class TestDestructor:
+    """Issue #36: __del__ must swallow Exception but let BaseException through."""
+
+    def test_del_swallows_normal_exception(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pulse")
+        b.close = lambda: (_ for _ in ()).throw(RuntimeError("cleanup boom"))
+        b.__del__()  # must not raise
+
+    def test_del_propagates_keyboard_interrupt(self, linux_mod, patch_strategies):
+        patch_strategies()
+        b = linux_mod.LinuxBackend(pid=1, engine="pulse")
+
+        def interrupt():
+            raise KeyboardInterrupt
+
+        b.close = interrupt
+        with pytest.raises(KeyboardInterrupt):
+            b.__del__()
+        # Neutralize close so the eventual GC __del__ doesn't re-raise during collection.
+        b.close = lambda: None

--- a/tests/test_linux_strategies.py
+++ b/tests/test_linux_strategies.py
@@ -1,0 +1,630 @@
+"""
+Characterization tests for the Linux PulseAudio / PipeWire capture strategies.
+
+These lock in the observable behaviour of ``PulseAudioStrategy`` and
+``PipeWireStrategy`` so the de-duplication refactor in Issue #26 (extracting a
+shared PulseAudio-compat base class) can be verified to preserve behaviour.
+
+The real backends need ``pulsectl`` (Linux only) plus the ``parec`` / ``pw-record``
+binaries, none of which exist in CI on macOS/Windows. We therefore inject a fake
+``pulsectl`` module and fake ``subprocess`` primitives so the pure orchestration
+logic can be exercised on any platform.
+"""
+
+import io
+import queue
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake pulsectl infrastructure
+# ---------------------------------------------------------------------------
+
+class FakeSinkInput:
+    def __init__(self, index, pid=None, name="App", stream_id=None, sink=0):
+        self.index = index
+        self.sink = sink
+        proplist = {"application.name": name}
+        if pid is not None:
+            proplist["application.process.id"] = str(pid)
+        if stream_id is not None:
+            proplist["pipewire.stream.id"] = stream_id
+        self.proplist = proplist
+
+
+class FakeSink:
+    def __init__(self, index, name, monitor_source_name="monitor.src"):
+        self.index = index
+        self.name = name
+        self.monitor_source_name = monitor_source_name
+
+
+class RaisingMonitorSink:
+    """A sink whose monitor_source_name access fails (step-3 error path)."""
+
+    def __init__(self, index, name):
+        self.index = index
+        self.name = name
+
+    @property
+    def monitor_source_name(self):
+        raise RuntimeError("monitor source unavailable")
+
+
+class FakePulse:
+    """Minimal stand-in for pulsectl.Pulse recording the calls made against it."""
+
+    def __init__(self, client_name=None):
+        self.client_name = client_name
+        self.closed = False
+        self.sink_inputs = []
+        self.sinks = []
+        self.loaded_modules = {}
+        self.moved = []
+        self._next_module = 100
+        # Error-injection switches
+        self.fail_module_load = False
+        self.fail_move = False
+        self.fail_unload = False
+        self.missing_monitor_sink = False
+        self.monitor_raises = False
+
+    def sink_input_list(self):
+        return list(self.sink_inputs)
+
+    def sink_input_info(self, index):
+        for si in self.sink_inputs:
+            if si.index == index:
+                return si
+        raise RuntimeError(f"no sink input {index}")
+
+    def sink_list(self):
+        return list(self.sinks)
+
+    def sink_info(self, index):
+        for s in self.sinks:
+            if s.index == index:
+                return s
+        raise RuntimeError(f"no sink {index}")
+
+    def module_load(self, name, args=""):
+        if self.fail_module_load:
+            raise RuntimeError("module_load failed")
+        idx = self._next_module
+        self._next_module += 1
+        self.loaded_modules[idx] = name
+        # Emulate the null-sink appearing with the requested sink_name.
+        sink_name = None
+        for token in args.split():
+            if token.startswith("sink_name="):
+                sink_name = token.split("=", 1)[1]
+                break
+        if sink_name and not self.missing_monitor_sink:
+            if self.monitor_raises:
+                self.sinks.append(RaisingMonitorSink(index=900 + idx, name=sink_name))
+            else:
+                self.sinks.append(FakeSink(index=900 + idx, name=sink_name))
+        return idx
+
+    def module_unload(self, index):
+        if self.fail_unload:
+            raise RuntimeError("module_unload failed")
+        self.loaded_modules.pop(index, None)
+
+    def sink_input_move(self, index, sink_index):
+        if self.fail_move:
+            raise RuntimeError("sink_input_move failed")
+        self.moved.append((index, sink_index))
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def fake_pulsectl(monkeypatch):
+    """Install a fake ``pulsectl`` module and make ``which pw-record`` succeed."""
+    fake_module = types.ModuleType("pulsectl")
+    fake_module.Pulse = FakePulse  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pulsectl", fake_module)
+
+    import proctap.backends.linux as linux_mod
+
+    # pw-record availability probe used by PipeWireStrategy.__init__
+    monkeypatch.setattr(
+        linux_mod.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0),
+    )
+    return fake_module
+
+
+@pytest.fixture
+def linux_mod():
+    import proctap.backends.linux as linux_mod
+    return linux_mod
+
+
+class NoRunThread:
+    """threading.Thread replacement that records config but never runs target."""
+
+    instances = []
+
+    def __init__(self, target=None, args=(), daemon=None, **kwargs):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+        NoRunThread.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        pass
+
+
+@pytest.fixture
+def no_threads(monkeypatch, linux_mod):
+    NoRunThread.instances = []
+    monkeypatch.setattr(linux_mod.threading, "Thread", NoRunThread)
+    return NoRunThread
+
+
+def _connected(strategy):
+    strategy.connect()
+    return strategy._pulse
+
+
+# ---------------------------------------------------------------------------
+# __init__ behaviour
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_pulse_defaults(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=42)
+        assert s._pid == 42
+        assert s._sample_rate == 44100
+        assert s._channels == 2
+        assert s._sample_width == 2
+        assert s._bits_per_sample == 16
+        assert s._audio_queue.maxsize == 50
+
+    def test_pipewire_defaults(self, linux_mod, no_threads):
+        s = linux_mod.PipeWireStrategy(pid=7)
+        assert s._pid == 7
+        assert s._sample_rate == 48000  # PipeWire default differs from PulseAudio
+        assert s._bits_per_sample == 16
+
+    def test_pulse_requires_pulsectl(self, monkeypatch, linux_mod):
+        monkeypatch.setitem(sys.modules, "pulsectl", None)  # import -> ImportError
+        with pytest.raises(RuntimeError, match="pulsectl"):
+            linux_mod.PulseAudioStrategy(pid=1)
+
+    def test_pipewire_requires_pwrecord(self, monkeypatch, linux_mod):
+        monkeypatch.setattr(
+            linux_mod.subprocess, "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        with pytest.raises(RuntimeError, match="pw-record"):
+            linux_mod.PipeWireStrategy(pid=1)
+
+    def test_pipewire_requires_pulsectl(self, monkeypatch, linux_mod):
+        monkeypatch.setitem(sys.modules, "pulsectl", None)
+        with pytest.raises(RuntimeError, match="pulsectl"):
+            linux_mod.PipeWireStrategy(pid=1)
+
+
+# ---------------------------------------------------------------------------
+# connect
+# ---------------------------------------------------------------------------
+
+class TestConnect:
+    @pytest.mark.parametrize("cls_name", ["PulseAudioStrategy", "PipeWireStrategy"])
+    def test_connect_success(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        s.connect()
+        assert isinstance(s._pulse, FakePulse)
+
+    @pytest.mark.parametrize("cls_name", ["PulseAudioStrategy", "PipeWireStrategy"])
+    def test_connect_failure_wrapped(self, monkeypatch, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+
+        def boom(*a, **k):
+            raise OSError("server down")
+
+        s._pulsectl = types.SimpleNamespace(Pulse=boom)
+        with pytest.raises(RuntimeError, match="Failed to connect"):
+            s.connect()
+
+
+# ---------------------------------------------------------------------------
+# find_process_stream
+# ---------------------------------------------------------------------------
+
+class TestFindProcessStream:
+    def test_not_connected_raises(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            s.find_process_stream(1)
+
+    def test_found(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1234)
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=1234, name="Music")]
+        assert s.find_process_stream(1234) is True
+        assert s._sink_input_index == 5
+
+    def test_not_found(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1234)
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=9999)]
+        assert s.find_process_stream(1234) is False
+        assert s._sink_input_index is None
+
+    def test_exception_returns_false(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        pulse = _connected(s)
+        pulse.sink_input_list = mock.Mock(side_effect=RuntimeError("boom"))
+        assert s.find_process_stream(1) is False
+
+    def test_pipewire_captures_stream_id(self, linux_mod):
+        s = linux_mod.PipeWireStrategy(pid=1234)
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=1234, stream_id="pw-77")]
+        assert s.find_process_stream(1234) is True
+        assert s._sink_input_index == 5
+        assert s._stream_id == "pw-77"
+
+
+# ---------------------------------------------------------------------------
+# start_capture + isolation setup
+# ---------------------------------------------------------------------------
+
+BOTH = ["PulseAudioStrategy", "PipeWireStrategy"]
+
+
+class TestStartCapture:
+    def _prepare(self, s):
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=s._pid, sink=3)]
+        pulse.sinks = [FakeSink(index=3, name="orig")]
+        s.find_process_stream(s._pid)
+        return pulse
+
+    def test_requires_stream(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        _connected(s)
+        with pytest.raises(RuntimeError, match="No sink-input"):
+            s.start_capture()
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_isolated_success_starts_thread(self, linux_mod, no_threads, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        pulse = self._prepare(s)
+        s.start_capture()
+        assert len(no_threads.instances) == 1
+        assert no_threads.instances[0].started
+        # sink-input was moved to the created null-sink
+        assert pulse.moved
+        assert s._null_sink_index is not None
+
+    def test_pulse_falls_back_to_monitor(self, linux_mod, no_threads):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        pulse = self._prepare(s)
+        pulse.fail_module_load = True  # isolation setup fails
+        s.start_capture()
+        assert s._isolation_mode == "monitor"
+        assert no_threads.instances[-1].started  # monitor capture thread started
+
+    def test_pipewire_has_no_monitor_fallback(self, linux_mod, no_threads):
+        s = linux_mod.PipeWireStrategy(pid=1)
+        pulse = self._prepare(s)
+        pulse.fail_module_load = True
+        with pytest.raises(RuntimeError, match="Failed to start PipeWire capture"):
+            s.start_capture()
+
+
+class TestSetupIsolatedCaptureErrors:
+    def _prepare(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=1, sink=3)]
+        pulse.sinks = [FakeSink(index=3, name="orig")]
+        s.find_process_stream(1)
+        s._original_sink_index = 3
+        s._sink_input_index = 5
+        return s, pulse
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_null_sink_load_failure(self, linux_mod, no_threads, cls_name):
+        s, pulse = self._prepare(linux_mod, cls_name)
+        pulse.fail_module_load = True
+        with pytest.raises(RuntimeError, match="Failed to load null-sink"):
+            s._setup_isolated_capture()
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_move_failure_unloads_null_sink(self, linux_mod, no_threads, cls_name):
+        s, pulse = self._prepare(linux_mod, cls_name)
+        pulse.fail_move = True
+        with pytest.raises(RuntimeError, match="move"):
+            s._setup_isolated_capture()
+        # null-sink module was unloaded during cleanup
+        assert pulse.loaded_modules == {}
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_move_failure_unload_also_fails(self, linux_mod, no_threads, cls_name):
+        # Exercises the swallow-on-cleanup path when unloading the null-sink
+        # after a failed move itself raises (Issue #36 bare-except location).
+        s, pulse = self._prepare(linux_mod, cls_name)
+        pulse.fail_move = True
+        pulse.fail_unload = True
+        with pytest.raises(RuntimeError, match="move"):
+            s._setup_isolated_capture()
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_missing_monitor_source(self, linux_mod, no_threads, cls_name):
+        s, pulse = self._prepare(linux_mod, cls_name)
+        pulse.missing_monitor_sink = True  # null-sink never appears in sink_list
+        with pytest.raises(RuntimeError):
+            s._setup_isolated_capture()
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_monitor_source_lookup_failure_cleans_up(self, linux_mod, no_threads, cls_name):
+        # Sink exists (move succeeds) but reading its monitor source fails at step 3.
+        s, pulse = self._prepare(linux_mod, cls_name)
+        pulse.monitor_raises = True
+        with pytest.raises(RuntimeError, match="monitor source"):
+            s._setup_isolated_capture()
+        # Step-3 failure must unwind the isolation modules it created.
+        assert s._null_sink_index is None
+
+
+# ---------------------------------------------------------------------------
+# capture command building + worker loop
+# ---------------------------------------------------------------------------
+
+class FakeProc:
+    def __init__(self, chunks, wait_timeout=False):
+        self.stdout = io.BytesIO(b"".join(chunks))
+        self.terminated = False
+        self.killed = False
+        self._wait_timeout = wait_timeout
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        if self._wait_timeout:
+            import subprocess as _sp
+            raise _sp.TimeoutExpired("cmd", timeout)
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+class TestCaptureWorker:
+    def _chunk_bytes(self, s):
+        frames = int(s._sample_rate * (s._chunk_duration_ms / 1000.0))
+        return frames * s._channels * s._sample_width
+
+    def test_pulse_uses_parec(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        cb = self._chunk_bytes(s)
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return FakeProc([b"\x01" * cb, b"\x02" * cb])
+
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", fake_popen)
+        s._capture_worker("mysource")
+        assert captured["cmd"][0] == "parec"
+        assert "mysource" in captured["cmd"]
+        assert s._audio_queue.qsize() == 2
+
+    def test_pipewire_uses_pwrecord(self, linux_mod, monkeypatch):
+        s = linux_mod.PipeWireStrategy(pid=1)
+        cb = self._chunk_bytes(s)
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return FakeProc([b"\x01" * cb])
+
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", fake_popen)
+        # Both strategies expose the same worker entrypoint after refactor; before
+        # refactor PipeWire uses _capture_worker_pwrecord. Call whichever exists.
+        worker = getattr(s, "_capture_worker_pwrecord", None) or s._capture_worker
+        worker("mysource")
+        assert captured["cmd"][0] == "pw-record"
+        assert s._audio_queue.qsize() == 1
+
+    def test_queue_full_drops_oldest(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        cb = self._chunk_bytes(s)
+        # Shrink the queue and pre-fill it so the worker must drop frames.
+        s._audio_queue = queue.Queue(maxsize=1)
+        s._audio_queue.put(b"old")
+
+        def fake_popen(cmd, **kwargs):
+            return FakeProc([b"\x03" * cb, b"\x04" * cb])
+
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", fake_popen)
+        s._capture_worker("src")
+        # Queue never exceeds its maxsize and ends with the newest chunk.
+        assert s._audio_queue.qsize() == 1
+        assert s._audio_queue.get() == b"\x04" * cb
+
+    def test_worker_popen_failure_is_logged_not_raised(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+
+        def boom(*a, **k):
+            raise FileNotFoundError("parec missing")
+
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", boom)
+        # Worker must swallow the error (runs on a background thread).
+        s._capture_worker("src")
+        assert s._audio_queue.qsize() == 0
+
+    def test_worker_no_stdout_breaks(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        proc = FakeProc([])
+        proc.stdout = None
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", lambda *a, **k: proc)
+        s._capture_worker("src")
+        assert s._audio_queue.qsize() == 0
+
+    def test_worker_read_exception_breaks(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        proc = FakeProc([])
+        proc.stdout = mock.Mock()
+        proc.stdout.read = mock.Mock(side_effect=OSError("read failed"))
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", lambda *a, **k: proc)
+        s._capture_worker("src")  # error is caught, loop breaks, no raise
+
+    def test_worker_wait_timeout_kills_proc(self, linux_mod, monkeypatch):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        cb = self._chunk_bytes(s)
+        proc = FakeProc([b"\x01" * cb], wait_timeout=True)
+        monkeypatch.setattr(linux_mod.subprocess, "Popen", lambda *a, **k: proc)
+        s._capture_worker("src")
+        assert proc.killed
+
+    def test_base_build_command_is_abstract(self, linux_mod):
+        base = linux_mod._PulseCompatStrategy
+        # The base class does not know how to build a recorder command.
+        inst = base.__new__(base)
+        with pytest.raises(NotImplementedError):
+            inst._build_capture_command("src")
+
+
+# ---------------------------------------------------------------------------
+# cleanup / stop / read / close / format
+# ---------------------------------------------------------------------------
+
+class TestCleanupAndLifecycle:
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_cleanup_restores_and_unloads(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        pulse = _connected(s)
+        pulse.sink_inputs = [FakeSinkInput(5, pid=1, sink=3)]
+        s._sink_input_index = 5
+        s._original_sink_index = 3
+        s._null_sink_index = 101
+        pulse.loaded_modules[101] = "module-null-sink"
+        s._cleanup_isolation_modules()
+        assert (5, 3) in pulse.moved            # restored to original sink
+        assert 101 not in pulse.loaded_modules  # null-sink unloaded
+        assert s._null_sink_index is None
+
+    def test_cleanup_unloads_remap_and_loopback(self, linux_mod):
+        # PulseAudioStrategy additionally tracks remap-source / loopback modules.
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        pulse = _connected(s)
+        s._remap_source_index = 201
+        s._loopback_module_index = 202
+        pulse.loaded_modules.update({201: "module-remap-source", 202: "module-loopback"})
+        s._cleanup_isolation_modules()
+        assert pulse.loaded_modules == {}
+        assert s._remap_source_index is None
+        assert s._loopback_module_index is None
+
+    def test_cleanup_remap_loopback_unload_failure_swallowed(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        pulse = _connected(s)
+        s._remap_source_index = 201
+        s._loopback_module_index = 202
+        pulse.loaded_modules.update({201: "module-remap-source", 202: "module-loopback"})
+        pulse.fail_unload = True
+        s._cleanup_isolation_modules()  # warnings logged, no raise
+        # Indices are still cleared in the finally blocks.
+        assert s._remap_source_index is None
+        assert s._loopback_module_index is None
+
+    def test_stop_capture_joins_live_thread(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        _connected(s)
+        joined = {"n": 0}
+
+        class LiveThread:
+            def is_alive(self_inner):
+                return True
+
+            def join(self_inner, timeout=None):
+                joined["n"] += 1
+
+        s._capture_thread = LiveThread()
+        s.stop_capture()
+        assert joined["n"] == 1
+
+    def test_monitor_capture_requires_original_sink(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        _connected(s)
+        s._original_sink_index = None
+        with pytest.raises(RuntimeError, match="Original sink index"):
+            s._setup_monitor_capture()
+
+    def test_cleanup_restore_failure_is_swallowed(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        pulse = _connected(s)
+        s._sink_input_index = 5
+        s._original_sink_index = 3
+        pulse.sink_input_info = mock.Mock(side_effect=RuntimeError("gone"))
+        s._cleanup_isolation_modules()  # must not raise
+
+    def test_cleanup_no_pulse_is_noop(self, linux_mod):
+        s = linux_mod.PulseAudioStrategy(pid=1)
+        s._pulse = None
+        s._cleanup_isolation_modules()  # returns early, no error
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_cleanup_unload_failure_is_swallowed(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        pulse = _connected(s)
+        s._null_sink_index = 101
+        pulse.loaded_modules[101] = "module-null-sink"
+        pulse.fail_unload = True
+        s._cleanup_isolation_modules()  # must not raise
+        assert s._null_sink_index is None
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_read_audio_returns_data(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        s._audio_queue.put(b"pcm")
+        assert s.read_audio(timeout=0.1) == b"pcm"
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_read_audio_empty_returns_none(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        assert s.read_audio(timeout=0.01) is None
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_stop_capture_sets_stop_event(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        _connected(s)
+        s.stop_capture()
+        assert s._stop_event.is_set()
+
+    @pytest.mark.parametrize("cls_name", BOTH)
+    def test_close_closes_pulse(self, linux_mod, cls_name):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        pulse = _connected(s)
+        s.close()
+        assert pulse.closed
+        assert s._pulse is None
+
+    @pytest.mark.parametrize(
+        "cls_name,rate", [("PulseAudioStrategy", 44100), ("PipeWireStrategy", 48000)]
+    )
+    def test_get_format(self, linux_mod, cls_name, rate):
+        s = getattr(linux_mod, cls_name)(pid=1)
+        fmt = s.get_format()
+        assert fmt == {"sample_rate": rate, "channels": 2, "bits_per_sample": 16}

--- a/tests/test_no_bare_except.py
+++ b/tests/test_no_bare_except.py
@@ -1,0 +1,35 @@
+"""
+Tests for Issue #36: eliminate bare ``except:`` clauses.
+
+A bare ``except:`` also swallows ``BaseException`` (KeyboardInterrupt,
+SystemExit), which hides bugs and blocks interrupts. Every handler should name
+at least ``Exception``. This is enforced statically over the backend sources.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+import proctap.backends as backends_pkg
+
+BACKENDS_DIR = pathlib.Path(backends_pkg.__file__).parent
+SOURCE_FILES = sorted(p.name for p in BACKENDS_DIR.glob("*.py"))
+
+
+def _bare_except_lines(path: pathlib.Path) -> list[int]:
+    tree = ast.parse(path.read_text())
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ExceptHandler) and node.type is None
+    ]
+
+
+@pytest.mark.parametrize("filename", SOURCE_FILES)
+def test_no_bare_except(filename):
+    path = BACKENDS_DIR / filename
+    assert _bare_except_lines(path) == [], (
+        f"{filename} has bare 'except:' clause(s) at lines "
+        f"{_bare_except_lines(path)}"
+    )

--- a/tests/test_no_bare_except.py
+++ b/tests/test_no_bare_except.py
@@ -18,7 +18,9 @@ SOURCE_FILES = sorted(p.name for p in BACKENDS_DIR.glob("*.py"))
 
 
 def _bare_except_lines(path: pathlib.Path) -> list[int]:
-    tree = ast.parse(path.read_text())
+    # Explicit UTF-8: sources contain non-ASCII comments and would otherwise fail
+    # to decode under Windows' default cp1252 locale encoding.
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     return [
         node.lineno
         for node in ast.walk(tree)

--- a/tests/test_resample_quality.py
+++ b/tests/test_resample_quality.py
@@ -1,0 +1,36 @@
+"""
+Tests for Issue #25: ResampleQuality type alias should be defined in a single
+location (DRY) and imported everywhere instead of redefined per module.
+"""
+
+import typing
+
+from proctap.backends import base
+
+
+class TestResampleQualitySingleSource:
+    """The ResampleQuality alias must have exactly one definition."""
+
+    def test_defined_in_base(self):
+        """base.py owns the canonical ResampleQuality alias."""
+        assert hasattr(base, "ResampleQuality")
+        # It is a typing.Literal['best', 'medium', 'fast']
+        assert typing.get_args(base.ResampleQuality) == ("best", "medium", "fast")
+
+    def test_core_reuses_base_alias(self):
+        """core.py must import the alias, not redefine it."""
+        from proctap import core
+
+        assert core.ResampleQuality is base.ResampleQuality
+
+    def test_backends_init_reuses_base_alias(self):
+        """backends/__init__.py must import the alias, not redefine it."""
+        from proctap import backends
+
+        assert backends.ResampleQuality is base.ResampleQuality
+
+    def test_converter_reuses_base_alias(self):
+        """converter.py must import the alias, not redefine it."""
+        from proctap.backends import converter
+
+        assert converter.ResampleQuality is base.ResampleQuality


### PR DESCRIPTION
Addresses the six **readability / refactor** issues (#25–36; the six Performance-labelled issues are out of scope for this PR). Each issue is a separate commit, developed test-first (TDD) with tests added to guard the refactor.

## Issues
| Commit | Issue | Change |
|--------|-------|--------|
| `refactor(#25)` | #25 | Centralize the `ResampleQuality` type alias in `backends/base.py`; core/converter/`backends.__init__` now import it instead of each redefining it. |
| `refactor(#26)` | #26 | Extract `_PulseCompatStrategy` base class; `PulseAudioStrategy` / `PipeWireStrategy` drop ~130 lines of duplicated isolation/capture/cleanup logic and only declare their identity + `_build_capture_command` (parec vs pw-record). `linux.py`: 610 → 483 statements. |
| `refactor(#29)` | #29 | Replace the 3–4 level nested try/except engine selection in `LinuxBackend.__init__` with a declarative strategy-chain (`_get_strategy_chain` + `_create_strategy`). Fallback order and errors unchanged. |
| `refactor(#34)` | #34 | Name the audio-format magic numbers (PCM normalization divisors / peaks, format-detection thresholds) and Linux buffer constants. Values unchanged. |
| `refactor(#36)` | #36 | Replace all six bare `except:` with `except Exception` (destructors now let `KeyboardInterrupt`/`SystemExit` propagate). |
| `refactor(#32)` | #32 | Document one `read()` sentinel convention (None = no usable data, non-empty bytes = a chunk, b'' never signals an error) and make Windows/Linux conversion-error paths return `None` instead of `b''`. Behaviour-equivalent for the worker loop. |

## Tests
New test modules add **97** tests (162 passing total, was 65), covering the refactored strategy classes (fake `pulsectl` + fake subprocess), engine/fallback selection, PCM conversion behaviour, a static "no bare except" AST check, `__del__` semantics and `read()` error handling. `mypy src/` is clean.

Behaviour is preserved throughout — these are readability/refactor changes verified by characterization tests written before each refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)