### PR TITLE
macOS: PID-based Core Audio Process Tap backend (revive + integrate + release CI) (#57)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -44,6 +44,25 @@ jobs:
           swift build -c release
           ls -la .build/arm64-apple-macosx/release/ || ls -la .build/x86_64-apple-macosx/release/
 
+      # macOS: Build + Developer ID sign + notarize the PID-based Process Tap
+      # helper and stage its .app into the package. Skipped (ScreenCaptureKit
+      # remains the macOS backend) when signing secrets are not configured.
+      - name: Build + sign + notarize Process Tap helper (macOS)
+        if: runner.os == 'macOS'
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+        run: |
+          if [ -z "$BUILD_CERTIFICATE_BASE64" ]; then
+            echo "No signing secrets set — skipping Process Tap helper."
+            exit 0
+          fi
+          bash src/proctap/swift/proctap-helper/ci_sign_notarize.sh
+
       - name: Install build backend
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -40,6 +40,25 @@ jobs:
           swift build -c release
           ls -la .build/arm64-apple-macosx/release/ || ls -la .build/x86_64-apple-macosx/release/
 
+      # macOS: Build + Developer ID sign + notarize the PID-based Process Tap
+      # helper and stage its .app into the package. Skipped when signing secrets
+      # are not configured (ScreenCaptureKit remains the macOS backend).
+      - name: Build + sign + notarize Process Tap helper (macOS)
+        if: runner.os == 'macOS'
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+        run: |
+          if [ -z "$BUILD_CERTIFICATE_BASE64" ]; then
+            echo "No signing secrets set — skipping Process Tap helper."
+            exit 0
+          fi
+          bash src/proctap/swift/proctap-helper/ci_sign_notarize.sh
+
       - name: Install build backend
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,10 @@ test_with_safari.sh
 # Intermediate documentation
 MACOS_SCREENCAPTUREKIT_SUMMARY.md
 SCREENCAPTUREKIT_IMPLEMENTATION.md
+
+# Claude Code local (personal) instructions
+CLAUDE.local.md
+
+# Signing secrets (never commit)
+*.p12
+.proctap_p12_pw

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,14 @@
 recursive-include src/proctap/swift/screencapture-audio *.swift
 include src/proctap/swift/screencapture-audio/Package.swift
 
+# Include Process Tap (PID-based) Swift helper source + build/sign scripts
+recursive-include src/proctap/swift/proctap-helper *.swift
+include src/proctap/swift/proctap-helper/Package.swift
+include src/proctap/swift/proctap-helper/Info.plist
+include src/proctap/swift/proctap-helper/proctap-helper.entitlements
+include src/proctap/swift/proctap-helper/*.sh
+include src/proctap/swift/proctap-helper/README.md
+
 # Include documentation
 include README.md
 include LICENSE

--- a/docs/macos-processtap-signing.md
+++ b/docs/macos-processtap-signing.md
@@ -1,0 +1,61 @@
+# macOS Process Tap helper — CI signing & notarization
+
+The PID-based Process Tap backend ships a Swift helper (`proctap-helper.app`)
+that must be **Developer ID signed and notarized** to capture audio on end-user
+machines without disabling SIP/AMFI. The release workflows
+([`publish-pypi.yml`](../.github/workflows/publish-pypi.yml),
+[`release-testpypi.yml`](../.github/workflows/release-testpypi.yml)) build, sign,
+notarize and stage the `.app` into the wheel via
+[`src/proctap/swift/proctap-helper/ci_sign_notarize.sh`](../src/proctap/swift/proctap-helper/ci_sign_notarize.sh).
+
+Signing runs only on version tags / manual dispatch (never on pull requests), so
+secrets are never exposed to untrusted PRs. When the secrets are absent the step
+is skipped and the wheel simply ships without the Process Tap helper —
+ScreenCaptureKit (bundleID-based) remains the macOS backend.
+
+## Required repository secrets
+
+Settings → Secrets and variables → Actions (same set as the maintainer's other
+Developer ID projects):
+
+| Secret | Value |
+|---|---|
+| `BUILD_CERTIFICATE_BASE64` | `base64 -i DeveloperID.p12` (Developer ID Application cert + key) |
+| `P12_PASSWORD` | the `.p12` export password |
+| `KEYCHAIN_PASSWORD` | any random string (temporary CI keychain) |
+| `ASC_KEY_ID` | App Store Connect API **Key ID** |
+| `ASC_ISSUER_ID` | App Store Connect API **Issuer ID** |
+| `ASC_KEY_P8_BASE64` | `base64 -i AuthKey_XXXX.p8` |
+
+Notarization uses the App Store Connect API key (`notarytool --key`), so no
+Apple ID / app-specific password is needed.
+
+## What the CI step does
+
+1. Imports the Developer ID cert into a throwaway keychain.
+2. `swift build -c release`, assembles `proctap-helper.app` (+ `Info.plist`).
+3. `codesign` with Developer ID, hardened runtime, `proctap-helper.entitlements`.
+4. `notarytool submit --wait` + `stapler staple` + `stapler validate`.
+5. Copies the signed/stapled `.app` to `src/proctap/bin/proctap-helper.app`, so
+   `setup.py` includes it in the wheel (`package_data`).
+
+## End-user requirement (runtime)
+
+Even with a notarized helper, each user must grant **Screen Recording**
+permission to `proctap-helper` once (System Settings › Privacy & Security ›
+Screen Recording) — this gates the tapped audio content. The backend launches
+the helper via LaunchServices so it registers there automatically on first run.
+
+## Local dry run
+
+You can exercise the same script locally with the maintainer's assets:
+
+```bash
+BUILD_CERTIFICATE_BASE64="$(base64 -i /path/DeveloperID.p12)" \
+P12_PASSWORD="$(cat /path/p12_password.txt)" \
+KEYCHAIN_PASSWORD=whatever \
+ASC_KEY_ID=PSNK88F46K \
+ASC_ISSUER_ID="$(cat /path/issuer.txt)" \
+ASC_KEY_P8_BASE64="$(base64 -i /path/AuthKey_PSNK88F46K.p8)" \
+  bash src/proctap/swift/proctap-helper/ci_sign_notarize.sh
+```

--- a/setup.py
+++ b/setup.py
@@ -110,12 +110,33 @@ else:
     print(f"WARNING: Platform '{platform.system()}' is not officially supported")
     print("The package will install but audio capture will not work")
 
+def _processtap_app_package_data():
+    """Enumerate a pre-staged, signed+notarized proctap-helper.app for packaging.
+
+    The Process Tap helper is NOT built here (it needs Developer ID signing +
+    notarization, done in CI by swift/proctap-helper/ci_sign_notarize.sh, which
+    stages the bundle into src/proctap/bin/proctap-helper.app). setup.py only
+    packages it when present.
+    """
+    app = Path("src/proctap/bin/proctap-helper.app")
+    if not app.is_dir():
+        return []
+    return [
+        str(p.relative_to("src/proctap"))
+        for p in app.rglob("*")
+        if p.is_file()
+    ]
+
+
 setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     ext_modules=ext_modules,
     package_data={
-        "proctap": ["bin/screencapture-audio"],  # Include ScreenCaptureKit Swift helper
+        "proctap": [
+            "bin/screencapture-audio",  # ScreenCaptureKit Swift helper (bundleID-based)
+            *_processtap_app_package_data(),  # signed Process Tap helper (.app), if staged
+        ],
     },
     cmdclass={
         "build_py": BuildPyCommand,

--- a/src/proctap/backends/__init__.py
+++ b/src/proctap/backends/__init__.py
@@ -64,7 +64,19 @@ def get_backend(pid: int, resample_quality: ResampleQuality = 'best') -> "AudioB
         import logging
         log = logging.getLogger(__name__)
 
-        # Try ScreenCaptureKit first (RECOMMENDED - macOS 13+, works on Apple Silicon)
+        # Try the PID-based Process Tap helper first when it is built + signed.
+        # This matches Windows/Linux per-PID semantics (vs ScreenCaptureKit's
+        # bundleID model). Requires the signed proctap-helper.app and Screen
+        # Recording permission granted to it.
+        try:
+            from .macos_processtap import ProcessTapBackend, is_available as pt_available
+            if pt_available():
+                log.info("Using Core Audio Process Tap backend (PID-based, macOS 14.4+)")
+                return ProcessTapBackend(pid=pid, resample_quality=resample_quality)
+        except ImportError as e:
+            log.debug(f"Process Tap backend not available: {e}")
+
+        # Try ScreenCaptureKit next (macOS 13+, bundleID-based, Apple Silicon compatible)
         try:
             from .macos_screencapture import ScreenCaptureBackend, is_available as sc_available
             if sc_available():

--- a/src/proctap/backends/macos_processtap.py
+++ b/src/proctap/backends/macos_processtap.py
@@ -1,0 +1,238 @@
+"""
+macOS PID-based Process Tap backend.
+
+Captures audio from a specific PID using the Core Audio Process Tap API via the
+signed Swift helper (``swift/proctap-helper``). Unlike the ScreenCaptureKit
+backend (which is bundleID-based), this matches the Windows/Linux per-PID
+semantics.
+
+Key detail: the Process Tap *audio content* is gated by Screen Recording
+permission granted to the process that runs the tap. Executing the helper as a
+child of Python inherits the parent's TCC identity and yields silence, so the
+helper is launched via LaunchServices (``open``) as its OWN responsible process.
+Because ``open`` cannot pipe stdout, PCM is streamed back through a FIFO.
+
+Requirements:
+- macOS 14.4+ (Process Tap API), verified on macOS 15.6 / Apple Silicon
+- The helper built + Developer ID signed (``swift/proctap-helper/build.sh``)
+- Screen Recording permission enabled for ``proctap-helper`` (one-time, in
+  System Settings › Privacy & Security › Screen Recording)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import queue
+import shutil
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+from .base import (
+    AudioBackend,
+    STANDARD_SAMPLE_RATE,
+    STANDARD_CHANNELS,
+    STANDARD_FORMAT,
+    STANDARD_SAMPLE_WIDTH,
+)
+from .converter import AudioConverter, SampleFormat
+
+log = logging.getLogger(__name__)
+
+# The Process Tap negotiates this native format (see helper "Tap format" log).
+TAP_SAMPLE_RATE = 44100
+TAP_CHANNELS = 2
+TAP_SAMPLE_WIDTH = 4  # float32
+_CHUNK_MS = 10
+
+
+def find_processtap_app() -> Optional[Path]:
+    """Locate the signed proctap-helper.app bundle (bundled first, then dev build)."""
+    pkg_dir = Path(__file__).parent.parent  # src/proctap
+    bundled = pkg_dir / "bin" / "proctap-helper.app"
+    if bundled.is_dir():
+        return bundled
+
+    helper_root = pkg_dir / "swift" / "proctap-helper"
+    build_dir = helper_root / ".build"
+    if build_dir.is_dir():
+        for arch_dir in build_dir.glob("*-apple-macosx"):
+            app = arch_dir / "release" / "proctap-helper.app"
+            if app.is_dir():
+                return app
+    return None
+
+
+def is_available() -> bool:
+    """True on macOS with the built helper app present."""
+    if platform.system() != "Darwin":
+        return False
+    try:
+        major = int(platform.mac_ver()[0].split(".")[0])
+    except (ValueError, IndexError):
+        return False
+    if major < 14:
+        return False
+    return find_processtap_app() is not None
+
+
+class ProcessTapBackend(AudioBackend):
+    """PID-based macOS capture via the Core Audio Process Tap Swift helper."""
+
+    def __init__(self, pid: int, resample_quality: str = "best") -> None:
+        super().__init__(pid)
+
+        self.app_bundle = find_processtap_app()
+        if not self.app_bundle:
+            raise RuntimeError(
+                "proctap-helper.app not found. Build it with "
+                "swift/proctap-helper/build.sh (Developer ID signing required)."
+            )
+        self._exe = self.app_bundle / "Contents" / "MacOS" / "proctap-helper"
+
+        self._tmpdir: Optional[str] = None
+        self._fifo_path: Optional[str] = None
+        self._helper_pid: Optional[int] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=100)
+        self._running = False
+
+        # Tap is 44.1kHz/2ch/float32 -> convert to standard 48kHz/2ch/float32.
+        self._converter = AudioConverter(
+            src_rate=TAP_SAMPLE_RATE,
+            src_channels=TAP_CHANNELS,
+            src_width=TAP_SAMPLE_WIDTH,
+            src_format=SampleFormat.FLOAT32,
+            dst_rate=STANDARD_SAMPLE_RATE,
+            dst_channels=STANDARD_CHANNELS,
+            dst_width=STANDARD_SAMPLE_WIDTH,
+            dst_format=SampleFormat.FLOAT32,
+            resample_quality=resample_quality,  # type: ignore[arg-type]
+            auto_detect_format=False,
+        )
+
+    def start(self) -> None:
+        if self._running:
+            log.warning("Already running")
+            return
+
+        self._tmpdir = tempfile.mkdtemp(prefix="proctap-")
+        self._fifo_path = os.path.join(self._tmpdir, "pcm.fifo")
+        os.mkfifo(self._fifo_path)
+
+        # Launch via LaunchServices so the helper is its own TCC responsible
+        # process (required for Screen-Recording-gated tap content).
+        log.info(f"Launching proctap-helper (open) for PID {self._pid}")
+        subprocess.run(
+            ["open", str(self.app_bundle), "--args", str(self._pid), self._fifo_path],
+            check=True,
+        )
+
+        self._running = True
+        self._reader_thread = threading.Thread(target=self._reader_worker, daemon=True)
+        self._reader_thread.start()
+        self._helper_pid = self._find_helper_pid()
+
+    def _find_helper_pid(self) -> Optional[int]:
+        try:
+            out = subprocess.run(
+                ["pgrep", "-f", f"proctap-helper.*{self._fifo_path}"],
+                capture_output=True, text=True, timeout=2,
+            )
+            pids = [int(p) for p in out.stdout.split()]
+            return pids[0] if pids else None
+        except Exception:
+            return None
+
+    def _reader_worker(self) -> None:
+        chunk_bytes = int(TAP_SAMPLE_RATE * TAP_CHANNELS * TAP_SAMPLE_WIDTH * _CHUNK_MS / 1000)
+        try:
+            # Opening the FIFO for read rendezvouses with the helper's write end.
+            with open(self._fifo_path, "rb") as fifo:  # type: ignore[arg-type]
+                while self._running:
+                    data = fifo.read(chunk_bytes)
+                    if not data:
+                        log.debug("FIFO EOF (helper exited)")
+                        break
+                    try:
+                        data = self._converter.convert(data)
+                    except Exception as e:
+                        log.error(f"Error converting tap audio: {e}")
+                        continue
+                    try:
+                        self._audio_queue.put(data, block=False)
+                    except queue.Full:
+                        log.warning("Audio queue full, dropping samples")
+        except Exception as e:
+            if self._running:
+                log.error(f"Error in reader thread: {e}")
+
+    def read(self, num_frames: int = 1024) -> bytes:
+        bytes_per_frame = STANDARD_CHANNELS * STANDARD_SAMPLE_WIDTH
+        total = num_frames * bytes_per_frame
+        result = bytearray(total)
+        got = 0
+        while got < total:
+            try:
+                chunk = self._audio_queue.get(timeout=1.0)
+                n = min(len(chunk), total - got)
+                result[got:got + n] = chunk[:n]
+                got += n
+            except queue.Empty:
+                if not self._running:
+                    break
+                continue
+        return bytes(result[:got])
+
+    def iter_chunks(self):
+        while self._running or not self._audio_queue.empty():
+            try:
+                yield self._audio_queue.get(timeout=0.1)
+            except queue.Empty:
+                if not self._running:
+                    break
+                continue
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+        log.info("Stopping proctap-helper capture")
+        self._running = False
+
+        # The helper is detached (launched via open); terminate it by PID.
+        pid = self._helper_pid or self._find_helper_pid()
+        if pid:
+            try:
+                os.kill(pid, 15)  # SIGTERM
+            except ProcessLookupError:
+                pass
+            except Exception as e:
+                log.debug(f"Could not terminate helper {pid}: {e}")
+
+        if self._reader_thread and self._reader_thread.is_alive():
+            self._reader_thread.join(timeout=1)
+
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            self._tmpdir = None
+            self._fifo_path = None
+
+        log.info("proctap-helper capture stopped")
+
+    def get_format(self) -> dict[str, int | str]:
+        return {
+            "sample_rate": STANDARD_SAMPLE_RATE,
+            "channels": STANDARD_CHANNELS,
+            "bits_per_sample": STANDARD_SAMPLE_WIDTH * 8,
+            "sample_format": STANDARD_FORMAT,
+        }
+
+    def __del__(self) -> None:
+        try:
+            self.stop()
+        except Exception:
+            pass

--- a/src/proctap/backends/macos_processtap.py
+++ b/src/proctap/backends/macos_processtap.py
@@ -93,6 +93,12 @@ class ProcessTapBackend(AudioBackend):
                 "swift/proctap-helper/build.sh (Developer ID signing required)."
             )
         self._exe = self.app_bundle / "Contents" / "MacOS" / "proctap-helper"
+        # Wheels don't preserve the executable bit on package_data; restore it.
+        try:
+            if self._exe.is_file() and not os.access(self._exe, os.X_OK):
+                self._exe.chmod(0o755)
+        except OSError:
+            pass
 
         self._tmpdir: Optional[str] = None
         self._fifo_path: Optional[str] = None

--- a/src/proctap/backends/macos_processtap.py
+++ b/src/proctap/backends/macos_processtap.py
@@ -128,7 +128,7 @@ class ProcessTapBackend(AudioBackend):
 
         self._tmpdir = tempfile.mkdtemp(prefix="proctap-")
         self._fifo_path = os.path.join(self._tmpdir, "pcm.fifo")
-        os.mkfifo(self._fifo_path)
+        os.mkfifo(self._fifo_path)  # type: ignore[attr-defined]  # macOS-only module
 
         # Launch via LaunchServices so the helper is its own TCC responsible
         # process (required for Screen-Recording-gated tap content).

--- a/src/proctap/swift/proctap-helper/Info.plist
+++ b/src/proctap/swift/proctap-helper/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>proctap-helper</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.proctap.helper</string>
+	<key>CFBundleName</key>
+	<string>ProcTap Helper</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.4</string>
+	<!-- Background helper: no Dock icon / UI. -->
+	<key>LSUIElement</key>
+	<true/>
+	<!-- TCC usage strings shown in the permission prompts. -->
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>ProcTap captures audio from a specific process using the Core Audio Process Tap API.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>ProcTap needs audio input access to capture per-process audio via Core Audio Process Tap.</string>
+</dict>
+</plist>

--- a/src/proctap/swift/proctap-helper/Package.swift
+++ b/src/proctap/swift/proctap-helper/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "proctap-helper",
+    platforms: [
+        .macOS(.v14)  // macOS 14.2+ required for Process Tap API
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "proctap-helper",
+            linkerSettings: [
+                .linkedFramework("AVFoundation")
+            ]
+        ),
+    ],
+    // Swift 5 language mode: the Core Audio IOProc block is invoked by CoreAudio
+    // on its own dispatch queue. Under the Swift 6 language mode the closure
+    // inherits @main's MainActor isolation and traps with a dispatch-queue
+    // executor assertion (_dispatch_assert_queue_fail) on the first callback.
+    swiftLanguageModes: [.v5]
+)

--- a/src/proctap/swift/proctap-helper/README.md
+++ b/src/proctap/swift/proctap-helper/README.md
@@ -55,18 +55,38 @@ With a Developer ID signature these fixes let the full pipeline run on Apple
 Silicon **without disabling SIP or AMFI**: translate-PID → Process Tap →
 Aggregate Device → IOProc streams PCM to stdout at 48 kHz/2 ch/float32.
 
-## Verifying real audio content (interactive)
+## Permissions — the key requirement
 
-Automated/headless runs stream buffers at the correct rate but may capture
-silence if the OS isn't actually rendering the target's audio in that session.
-Verify from a normal Terminal while real audio plays:
+**Screen Recording permission gates the tapped audio content**, and it must be
+granted to the *responsible process* that runs the helper. A tap created without
+it is returned successfully but delivers **silence** (not an error).
+
+`CGPreflightScreenCaptureAccess()` reports the true state (unlike
+`CGWindowListCopyWindowInfo`, which returns window metadata even without the
+permission — a false positive). The simplest way to give the helper its own TCC
+identity is to launch it via LaunchServices (`open`), which also registers it in
+System Settings › Privacy & Security › Screen Recording:
 
 ```bash
-APP=".build/$(uname -m)-apple-macosx/release/proctap-helper.app/Contents/MacOS/proctap-helper"
-# Play something audible (Music.app, a browser video, etc.), find its PID, then:
-"$APP" <PID> > /tmp/cap.f32
-# Convert float32 PCM -> WAV and listen:
-ffmpeg -f f32le -ar 48000 -ac 2 -i /tmp/cap.f32 /tmp/cap.wav && afplay /tmp/cap.wav
+APP_BUNDLE=".build/$(uname -m)-apple-macosx/release/proctap-helper.app"
+open "$APP_BUNDLE" --args <PID> /tmp/cap.f32     # 2nd arg = output file (open can't pipe stdout)
+# First run registers the helper under Screen Recording; enable it there, then re-run.
 ```
 
-Grant the Microphone + Screen Recording prompts the first time.
+When exec'd directly (piping stdout) the helper runs under the parent's TCC
+identity; that inherits the parent's grants for the *check* but the tap content
+stays silent unless the responsible process truly holds Screen Recording.
+
+## Verifying real audio content
+
+Verified working on macOS 15.6 / Apple Silicon: capturing Chrome's audio-service
+process (YouTube) yields real stereo audio at 44.1 kHz/float32.
+
+```bash
+# Chrome routes all tab audio through its AudioService process:
+PID=$(pgrep -f "audio.mojom.AudioService" | head -1)
+open "$APP_BUNDLE" --args "$PID" /tmp/cap.f32     # let audio play a few seconds
+pkill -f proctap-helper
+# Tap format is 44.1 kHz / 2 ch / float32:
+ffmpeg -f f32le -ar 44100 -ac 2 -i /tmp/cap.f32 /tmp/cap.wav -y && afplay /tmp/cap.wav
+```

--- a/src/proctap/swift/proctap-helper/README.md
+++ b/src/proctap/swift/proctap-helper/README.md
@@ -1,0 +1,72 @@
+# proctap-helper — PID-based Core Audio Process Tap helper (macOS)
+
+A Swift CLI that captures audio from a **specific PID** using the Core Audio
+Process Tap API (`AudioHardwareCreateProcessTap` + `CATapDescription`), streaming
+raw PCM to stdout. This gives macOS the same per-process (PID) capture semantics
+as the Windows (WASAPI) and Linux (PipeWire/PulseAudio) backends, instead of the
+bundleID-based ScreenCaptureKit backend.
+
+Revived from `archive/apple-silicon-investigation-20251120/` for issue #57.
+
+## Requirements
+
+- macOS 14.4+ (Process Tap API; developed/verified on macOS 15.6)
+- A valid **Developer ID Application** signature (see below) — the API works on
+  a normal SIP/AMFI-enabled system, it just requires a validly signed binary.
+- TCC consent at runtime (Microphone + Screen Recording), granted once.
+
+## Build & sign
+
+```bash
+# Build + bundle + sign (auto-detects a Developer ID Application identity):
+./build.sh
+
+# Or sign headlessly from a .p12 (works in non-interactive sessions):
+./build.sh --no-sign
+./sign_with_p12.sh /path/to/DeveloperID.p12 /path/to/password-file
+
+# Output: .build/<arch>-apple-macosx/release/proctap-helper.app
+```
+
+Run: `proctap-helper.app/Contents/MacOS/proctap-helper <PID>` → raw PCM on stdout
+(48 kHz, 2 ch, float32 interleaved), diagnostics on stderr.
+
+For redistribution, notarize + staple the `.app` (see build.sh footer).
+
+## What was fixed reviving it (all in `Sources/proctap-helper/main.swift`)
+
+The archived helper reached "implementation complete, blocked only by signing".
+After signing it still failed; the real blockers were:
+
+1. **Wrong selector FourCC.** It used `'pid2'` (`0x70696432`) for
+   `kAudioHardwarePropertyTranslatePIDToProcessObject`; the correct code is
+   `'id2p'`. This — not AMFI — caused the `status=2003332927` ("wat?") failure.
+   Now uses the named SDK constant.
+2. **Fragile Objective-C runtime construction of `CATapDescription`** (via
+   `unsafeBitCast`/`perform`) crashed with a bus error on macOS 15. `CATapDescription`
+   is public since macOS 14.4, so it is now constructed directly:
+   `CATapDescription(stereoMixdownOfProcesses:)`.
+3. **Swift 6 concurrency trap.** The IOProc block inherited `@main`'s MainActor
+   isolation and hit `_dispatch_assert_queue_fail` when CoreAudio invoked it on
+   its own dispatch queue. Fixed by building in **Swift 5 language mode**
+   (`Package.swift` → `swiftLanguageModes: [.v5]`).
+
+With a Developer ID signature these fixes let the full pipeline run on Apple
+Silicon **without disabling SIP or AMFI**: translate-PID → Process Tap →
+Aggregate Device → IOProc streams PCM to stdout at 48 kHz/2 ch/float32.
+
+## Verifying real audio content (interactive)
+
+Automated/headless runs stream buffers at the correct rate but may capture
+silence if the OS isn't actually rendering the target's audio in that session.
+Verify from a normal Terminal while real audio plays:
+
+```bash
+APP=".build/$(uname -m)-apple-macosx/release/proctap-helper.app/Contents/MacOS/proctap-helper"
+# Play something audible (Music.app, a browser video, etc.), find its PID, then:
+"$APP" <PID> > /tmp/cap.f32
+# Convert float32 PCM -> WAV and listen:
+ffmpeg -f f32le -ar 48000 -ac 2 -i /tmp/cap.f32 /tmp/cap.wav && afplay /tmp/cap.wav
+```
+
+Grant the Microphone + Screen Recording prompts the first time.

--- a/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
+++ b/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
@@ -1,0 +1,309 @@
+import Foundation
+import CoreAudio
+import AudioToolbox
+import AVFoundation
+
+// Private Core Audio APIs
+@_silgen_name("AudioHardwareCreateProcessTap")
+func AudioHardwareCreateProcessTap(_ tapDescription: AnyObject, _ outTapID: UnsafeMutablePointer<AudioObjectID>) -> OSStatus
+
+@_silgen_name("AudioHardwareDestroyProcessTap")
+func AudioHardwareDestroyProcessTap(_ tapID: AudioObjectID) -> OSStatus
+
+@available(macOS 14.2, *)
+func requestMicrophonePermission() -> Bool {
+    fputs("Requesting microphone permission...\n", stderr)
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var granted = false
+
+    AVCaptureDevice.requestAccess(for: .audio) { result in
+        granted = result
+        if result {
+            fputs("Microphone permission granted\n", stderr)
+        } else {
+            fputs("Microphone permission denied\n", stderr)
+        }
+        semaphore.signal()
+    }
+
+    // Wait for permission response (with timeout)
+    let timeout = DispatchTime.now() + .seconds(60)
+    let result = semaphore.wait(timeout: timeout)
+
+    if result == .timedOut {
+        fputs("WARNING: Permission request timed out\n", stderr)
+        return false
+    }
+
+    return granted
+}
+
+@available(macOS 14.2, *)
+func checkScreenRecordingPermission() -> Bool {
+    // Screen Recording permission is required to access other processes' audio
+    // We check this by attempting to get the list of windows
+    let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]]
+
+    if let windows = windowList, windows.count > 0 {
+        fputs("Screen Recording permission: Granted\n", stderr)
+        return true
+    } else {
+        fputs("ERROR: Screen Recording permission required\n", stderr)
+        fputs("Please grant Screen Recording access in System Settings > Privacy & Security > Screen Recording\n", stderr)
+        fputs("This permission is needed to access audio from other processes.\n", stderr)
+        return false
+    }
+}
+
+@available(macOS 14.2, *)
+func checkMicrophonePermission() -> Bool {
+    let status = AVCaptureDevice.authorizationStatus(for: .audio)
+
+    switch status {
+    case .authorized:
+        fputs("Microphone permission: Already authorized\n", stderr)
+        return true
+    case .notDetermined:
+        fputs("Microphone permission: Not determined, requesting...\n", stderr)
+        return requestMicrophonePermission()
+    case .denied:
+        fputs("ERROR: Microphone permission denied\n", stderr)
+        fputs("Please grant microphone access in System Settings > Privacy & Security > Microphone\n", stderr)
+        return false
+    case .restricted:
+        fputs("ERROR: Microphone access is restricted\n", stderr)
+        return false
+    @unknown default:
+        fputs("WARNING: Unknown microphone permission status\n", stderr)
+        return false
+    }
+}
+
+@available(macOS 14.2, *)
+func checkAllPermissions() -> Bool {
+    var allGranted = true
+
+    // Check microphone permission
+    if !checkMicrophonePermission() {
+        allGranted = false
+    }
+
+    // Check screen recording permission (needed for process audio access)
+    if !checkScreenRecordingPermission() {
+        allGranted = false
+    }
+
+    return allGranted
+}
+
+@available(macOS 14.2, *)
+func findProcessAudioObject(pid: pid_t) -> AudioObjectID? {
+    // Use kAudioHardwarePropertyTranslatePIDToProcessObject (public since macOS 14.4).
+    // NOTE: the archived code used the wrong FourCC 'pid2' (0x70696432); the correct
+    // selector is 'id2p'. Using the named constant avoids that class of bug.
+    var propertyAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+
+    var processObjectID: AudioObjectID = 0
+    var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+    var qualifierData = pid
+    let qualifierSize = UInt32(MemoryLayout<pid_t>.size)
+
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject),
+        &propertyAddress,
+        qualifierSize,
+        &qualifierData,
+        &dataSize,
+        &processObjectID
+    )
+
+    if status == noErr && processObjectID != 0 {
+        fputs("Found process object ID \(processObjectID) for PID \(pid)\n", stderr)
+        return processObjectID
+    } else {
+        fputs("ERROR: Failed to translate PID \(pid) to process object (status=\(status), objectID=\(processObjectID))\n", stderr)
+        return nil
+    }
+}
+
+@available(macOS 14.2, *)
+@main
+struct ProcTapHelper {
+    static func main() {
+        let args = CommandLine.arguments
+
+        guard args.count >= 2 else {
+            fputs("Usage: proctap-helper <PID>\n", stderr)
+            exit(1)
+        }
+
+        guard let pid = pid_t(args[1]) else {
+            fputs("Error: Invalid PID\n", stderr)
+            exit(1)
+        }
+
+        fputs("ProcTap Helper starting for PID \(pid)\n", stderr)
+
+        // Check and request all required permissions
+        if !checkAllPermissions() {
+            fputs("Error: Required permissions not granted\n", stderr)
+            exit(1)
+        }
+
+        guard let processObjectID = findProcessAudioObject(pid: pid) else {
+            fputs("Error: Process \(pid) has no audio\n", stderr)
+            exit(1)
+        }
+
+        fputs("Found process audio object: \(processObjectID)\n", stderr)
+
+        // CATapDescription is a public class since macOS 14.4. Construct it
+        // directly instead of via fragile Objective-C runtime calls (the old
+        // unsafeBitCast path crashed with a bus error on macOS 15).
+        let tapUUID = UUID()
+        let tapDescription = CATapDescription(stereoMixdownOfProcesses: [processObjectID])
+        tapDescription.uuid = tapUUID
+
+        fputs("Created tap description\n", stderr)
+
+        // Create Process Tap
+        var tapDeviceID: AudioObjectID = 0
+        var status = AudioHardwareCreateProcessTap(tapDescription, &tapDeviceID)
+
+        guard status == noErr, tapDeviceID != 0 else {
+            fputs("Error: Failed to create Process Tap (status=\(status))\n", stderr)
+            exit(1)
+        }
+
+        fputs("Process Tap created: device ID \(tapDeviceID)\n", stderr)
+
+        // Get default output device
+        var defaultOutputPropertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var defaultOutputID: AudioObjectID = 0
+        var outputSize = UInt32(MemoryLayout<AudioObjectID>.size)
+
+        status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultOutputPropertyAddress,
+            0, nil,
+            &outputSize,
+            &defaultOutputID
+        )
+
+        guard status == noErr else {
+            fputs("Error: Failed to get default output device\n", stderr)
+            AudioHardwareDestroyProcessTap(tapDeviceID)
+            exit(1)
+        }
+
+        // Get output device UID
+        var uidPropertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var outputUID: Unmanaged<CFString>?
+        var uidSize = UInt32(MemoryLayout<CFString>.size)
+
+        status = AudioObjectGetPropertyData(
+            defaultOutputID,
+            &uidPropertyAddress,
+            0, nil,
+            &uidSize,
+            &outputUID
+        )
+
+        let outputUIDString: String
+        if status == noErr, let uid = outputUID?.takeUnretainedValue() as String? {
+            outputUIDString = uid
+        } else {
+            outputUIDString = "BuiltInSpeakerDevice"
+        }
+
+        // Create Aggregate Device
+        let aggregateUID = UUID().uuidString
+
+        let description: [String: Any] = [
+            "name": "ProcTap-\(pid)",
+            "uid": aggregateUID,
+            "private": true,
+            "stacked": false,
+            "autostart": true,
+            "master": outputUIDString,
+            "subdevices": [
+                ["uid": outputUIDString]
+            ],
+            "taps": [
+                [
+                    "drift": true,
+                    "uid": tapUUID.uuidString
+                ]
+            ]
+        ]
+
+        var aggregateDeviceID: AudioObjectID = 0
+        status = AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateDeviceID)
+
+        guard status == noErr, aggregateDeviceID != 0 else {
+            fputs("Error: Failed to create Aggregate Device (status=\(status))\n", stderr)
+            AudioHardwareDestroyProcessTap(tapDeviceID)
+            exit(1)
+        }
+
+        fputs("Aggregate Device created\n", stderr)
+
+        // Create IOProc with block
+        let queue = DispatchQueue(label: "com.proctap.ioproc", qos: .userInitiated)
+
+        var ioProcID: AudioDeviceIOProcID?
+
+        status = AudioDeviceCreateIOProcIDWithBlock(
+            &ioProcID,
+            aggregateDeviceID,
+            queue
+        ) { (now, inputData, inputTime, outputData, outputTime) in
+            // The tapped audio arrives as a single interleaved stereo stream.
+            let abl = UnsafeMutableAudioBufferListPointer(
+                UnsafeMutablePointer(mutating: inputData))
+            guard let buffer = abl.first, let data = buffer.mData else { return }
+            let size = Int(buffer.mDataByteSize)
+            let bytePtr = data.bindMemory(to: UInt8.self, capacity: size)
+            FileHandle.standardOutput.write(Data(UnsafeBufferPointer(start: bytePtr, count: size)))
+        }
+
+        guard status == noErr, let procID = ioProcID else {
+            fputs("Error: Failed to create IOProc (status=\(status))\n", stderr)
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            AudioHardwareDestroyProcessTap(tapDeviceID)
+            exit(1)
+        }
+
+        // Start device
+        status = AudioDeviceStart(aggregateDeviceID, procID)
+
+        guard status == noErr else {
+            fputs("Error: Failed to start device (status=\(status))\n", stderr)
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            AudioHardwareDestroyProcessTap(tapDeviceID)
+            exit(1)
+        }
+
+        fputs("Ready\n", stderr)
+
+        // Run forever
+        // Note: Signal handling is managed by parent process
+        RunLoop.main.run()
+    }
+}

--- a/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
+++ b/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
@@ -182,6 +182,35 @@ struct ProcTapHelper {
 
         fputs("Process Tap created: device ID \(tapDeviceID)\n", stderr)
 
+        // Read the tap's ACTUAL UID; the aggregate's tap list must reference this
+        // (not merely the description's UUID) or the aggregate input is the phantom
+        // silent input of the output subdevice instead of the tap.
+        var tapUIDAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var tapUIDRef: Unmanaged<CFString>?
+        var tapUIDSize = UInt32(MemoryLayout<CFString>.size)
+        let tapUIDStatus = AudioObjectGetPropertyData(
+            tapDeviceID, &tapUIDAddr, 0, nil, &tapUIDSize, &tapUIDRef)
+        let tapUIDString: String = (tapUIDStatus == noErr)
+            ? (tapUIDRef?.takeRetainedValue() as String? ?? tapUUID.uuidString)
+            : tapUUID.uuidString
+        fputs("Tap UID: \(tapUIDString) (desc uuid: \(tapUUID.uuidString), status=\(tapUIDStatus))\n", stderr)
+
+        // Read the tap's actual stream format (0 ch / 0 Hz => tap not really configured).
+        var tapFmtAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var tapASBD = AudioStreamBasicDescription()
+        var tapFmtSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        let tapFmtStatus = AudioObjectGetPropertyData(
+            tapDeviceID, &tapFmtAddr, 0, nil, &tapFmtSize, &tapASBD)
+        fputs("Tap format: status=\(tapFmtStatus) rate=\(tapASBD.mSampleRate) ch=\(tapASBD.mChannelsPerFrame) bits=\(tapASBD.mBitsPerChannel) flags=\(tapASBD.mFormatFlags) bytesPerFrame=\(tapASBD.mBytesPerFrame)\n", stderr)
+
         // Get default output device
         var defaultOutputPropertyAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultOutputDevice,
@@ -214,7 +243,7 @@ struct ProcTapHelper {
         )
 
         var outputUID: Unmanaged<CFString>?
-        var uidSize = UInt32(MemoryLayout<CFString>.size)
+        var uidSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
 
         status = AudioObjectGetPropertyData(
             defaultOutputID,
@@ -225,21 +254,28 @@ struct ProcTapHelper {
         )
 
         let outputUIDString: String
-        if status == noErr, let uid = outputUID?.takeUnretainedValue() as String? {
-            outputUIDString = uid
+        if status == noErr, let uid = outputUID?.takeRetainedValue() {
+            outputUIDString = uid as String
         } else {
+            fputs("WARNING: could not read default output UID (status=\(status)); using fallback\n", stderr)
             outputUIDString = "BuiltInSpeakerDevice"
         }
 
         // Create Aggregate Device
         let aggregateUID = UUID().uuidString
 
+        // NOTE: the tap auto-start key is "tapautostart" (kAudioAggregateDeviceTapAutoStartKey);
+        // the archived code used "autostart", which is ignored, so the tap was never
+        // started and delivered silence.
+        // Aggregate device wrapping the process tap (AudioCap-style). The tap auto-start
+        // key is "tapautostart" (kAudioAggregateDeviceTapAutoStartKey) — the archived
+        // code used "autostart", which is ignored.
         let description: [String: Any] = [
             "name": "ProcTap-\(pid)",
             "uid": aggregateUID,
             "private": true,
             "stacked": false,
-            "autostart": true,
+            "tapautostart": true,
             "master": outputUIDString,
             "subdevices": [
                 ["uid": outputUIDString]
@@ -247,10 +283,11 @@ struct ProcTapHelper {
             "taps": [
                 [
                     "drift": true,
-                    "uid": tapUUID.uuidString
+                    "uid": tapUIDString
                 ]
             ]
         ]
+        fputs("Aggregate output master UID: \(outputUIDString)\n", stderr)
 
         var aggregateDeviceID: AudioObjectID = 0
         status = AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateDeviceID)

--- a/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
+++ b/src/proctap/swift/proctap-helper/Sources/proctap-helper/main.swift
@@ -41,19 +41,22 @@ func requestMicrophonePermission() -> Bool {
 
 @available(macOS 14.2, *)
 func checkScreenRecordingPermission() -> Bool {
-    // Screen Recording permission is required to access other processes' audio
-    // We check this by attempting to get the list of windows
-    let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]]
+    // Screen Recording permission gates Process Tap *audio content* (a tap without
+    // it is created fine but delivers silence). Use the real preflight API, not
+    // CGWindowListCopyWindowInfo (which returns window metadata even WITHOUT the
+    // permission and so gives a false positive).
+    let has = CGPreflightScreenCaptureAccess()
+    fputs("Screen Recording preflight: \(has)\n", stderr)
+    if has { return true }
 
-    if let windows = windowList, windows.count > 0 {
-        fputs("Screen Recording permission: Granted\n", stderr)
-        return true
-    } else {
-        fputs("ERROR: Screen Recording permission required\n", stderr)
-        fputs("Please grant Screen Recording access in System Settings > Privacy & Security > Screen Recording\n", stderr)
-        fputs("This permission is needed to access audio from other processes.\n", stderr)
-        return false
+    // Not granted: ask the system to register/prompt this binary.
+    let granted = CGRequestScreenCaptureAccess()
+    fputs("Screen Recording request result: \(granted)\n", stderr)
+    if !granted {
+        fputs("ERROR: Screen Recording permission required. Enable it for this binary in\n", stderr)
+        fputs("System Settings > Privacy & Security > Screen Recording, then relaunch.\n", stderr)
     }
+    return granted
 }
 
 @available(macOS 14.2, *)
@@ -147,6 +150,21 @@ struct ProcTapHelper {
             exit(1)
         }
 
+        // Optional 2nd arg: output file path. Lets the helper be launched via
+        // LaunchServices (`open`) — which can't pipe stdout — so it runs as its
+        // own TCC responsible process. PCM is written here instead of stdout.
+        if args.count >= 3 {
+            let outPath = args[2]
+            // When launched via `open`, stderr is detached; mirror it to a log file.
+            _ = freopen(outPath + ".log", "w", stderr)
+            setvbuf(stderr, nil, _IONBF, 0)  // unbuffered so the log is live
+            if freopen(outPath, "wb", stdout) == nil {
+                fputs("Error: cannot open output file \(outPath)\n", stderr)
+                exit(1)
+            }
+            fputs("Writing PCM to file: \(outPath)\n", stderr)
+        }
+
         fputs("ProcTap Helper starting for PID \(pid)\n", stderr)
 
         // Check and request all required permissions
@@ -161,6 +179,18 @@ struct ProcTapHelper {
         }
 
         fputs("Found process audio object: \(processObjectID)\n", stderr)
+
+        // DIAGNOSTIC: is the tapped process actually rendering output audio right now?
+        var runAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyIsRunningOutput,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var isRunningOut: UInt32 = 0
+        var runSize = UInt32(MemoryLayout<UInt32>.size)
+        let runStatus = AudioObjectGetPropertyData(
+            processObjectID, &runAddr, 0, nil, &runSize, &isRunningOut)
+        fputs("Process isRunningOutput=\(isRunningOut) (status=\(runStatus))\n", stderr)
 
         // CATapDescription is a public class since macOS 14.4. Construct it
         // directly instead of via fragile Objective-C runtime calls (the old

--- a/src/proctap/swift/proctap-helper/build.sh
+++ b/src/proctap/swift/proctap-helper/build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Build, bundle and (Developer ID) sign the ProcTap Process Tap helper.
+#
+# The Core Audio Process Tap API works on a normal (SIP/AMFI-enabled) system as
+# long as the binary is validly signed with a Developer ID and the user grants
+# the audio-capture TCC permission at runtime. This script produces a signed
+# .app bundle ready for that.
+#
+# Usage:
+#   ./build.sh                      # build + bundle + sign (auto-detect Developer ID)
+#   CODESIGN_IDENTITY="Developer ID Application: NAME (TEAMID)" ./build.sh
+#   ./build.sh --no-sign            # build + bundle only (ad-hoc, for local dev)
+#
+# Output: .build/<arch>-apple-macosx/release/proctap-helper.app
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+APP_NAME="proctap-helper"
+BUNDLE_ID="com.proctap.helper"
+ENTITLEMENTS="proctap-helper.entitlements"
+INFO_PLIST="Info.plist"
+
+SIGN=1
+if [[ "${1:-}" == "--no-sign" ]]; then
+    SIGN=0
+fi
+
+echo "==> swift build -c release"
+swift build -c release
+
+# Resolve the release build dir (architecture-specific).
+BIN_PATH="$(swift build -c release --show-bin-path)"
+APP_BUNDLE="${BIN_PATH}/${APP_NAME}.app"
+MACOS_DIR="${APP_BUNDLE}/Contents/MacOS"
+
+echo "==> Assembling app bundle: ${APP_BUNDLE}"
+rm -rf "${APP_BUNDLE}"
+mkdir -p "${MACOS_DIR}"
+cp "${BIN_PATH}/${APP_NAME}" "${MACOS_DIR}/${APP_NAME}"
+cp "${INFO_PLIST}" "${APP_BUNDLE}/Contents/Info.plist"
+
+if [[ "${SIGN}" -eq 0 ]]; then
+    echo "==> Ad-hoc signing (--no-sign): local dev only, not distributable"
+    codesign --force --sign - --entitlements "${ENTITLEMENTS}" "${APP_BUNDLE}"
+    codesign -dv "${APP_BUNDLE}" 2>&1 | grep -E "Identifier|Signature" || true
+    echo "Done (ad-hoc): ${APP_BUNDLE}"
+    exit 0
+fi
+
+# Auto-detect a Developer ID Application identity unless one is provided.
+IDENTITY="${CODESIGN_IDENTITY:-}"
+if [[ -z "${IDENTITY}" ]]; then
+    IDENTITY="$(security find-identity -v -p codesigning \
+        | awk -F'"' '/Developer ID Application/{print $2; exit}')"
+fi
+
+if [[ -z "${IDENTITY}" ]]; then
+    echo "ERROR: No 'Developer ID Application' identity found." >&2
+    echo "       Set CODESIGN_IDENTITY=... or run with --no-sign for local dev." >&2
+    exit 1
+fi
+
+echo "==> Signing with: ${IDENTITY}"
+codesign --force \
+         --sign "${IDENTITY}" \
+         --entitlements "${ENTITLEMENTS}" \
+         --options runtime \
+         --timestamp \
+         "${APP_BUNDLE}"
+
+echo "==> Verifying signature"
+codesign --verify --strict --verbose=2 "${APP_BUNDLE}"
+codesign -dv --verbose=4 "${APP_BUNDLE}" 2>&1 | grep -E "Identifier|Authority|TeamIdentifier|Runtime" || true
+
+echo ""
+echo "Signed bundle: ${APP_BUNDLE}"
+echo "Executable:    ${MACOS_DIR}/${APP_NAME}"
+echo ""
+echo "Next (for redistribution): notarize with"
+echo "  xcrun notarytool submit <zip> --keychain-profile <profile> --wait"
+echo "  xcrun stapler staple \"${APP_BUNDLE}\""

--- a/src/proctap/swift/proctap-helper/ci_sign_notarize.sh
+++ b/src/proctap/swift/proctap-helper/ci_sign_notarize.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# CI: build, Developer ID sign, notarize + staple proctap-helper.app, and stage
+# it into the Python package (src/proctap/bin/proctap-helper.app) for wheel
+# packaging.
+#
+# Driven entirely by environment variables (GitHub Actions secrets), so it runs
+# only on tags / manual dispatch — never on untrusted pull requests.
+#
+#   Signing:
+#     BUILD_CERTIFICATE_BASE64   base64 of the Developer ID Application .p12
+#     P12_PASSWORD               .p12 export password
+#     KEYCHAIN_PASSWORD          any random string (temporary keychain)
+#   Notarization (App Store Connect API key):
+#     ASC_KEY_ID                 API Key ID
+#     ASC_ISSUER_ID              API Issuer ID
+#     ASC_KEY_P8_BASE64          base64 of AuthKey_XXXX.p8
+#
+# RUNNER_TEMP defaults to a mktemp dir when run outside GitHub Actions.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+: "${BUILD_CERTIFICATE_BASE64:?}" ; : "${P12_PASSWORD:?}" ; : "${KEYCHAIN_PASSWORD:?}"
+: "${ASC_KEY_ID:?}" ; : "${ASC_ISSUER_ID:?}" ; : "${ASC_KEY_P8_BASE64:?}"
+: "${RUNNER_TEMP:=$(mktemp -d)}"
+
+ENTITLEMENTS="proctap-helper.entitlements"
+INFO_PLIST="Info.plist"
+KEYCHAIN="$RUNNER_TEMP/proctap-signing.keychain-db"
+
+cleanup() { security delete-keychain "$KEYCHAIN" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "==> Import Developer ID cert into a temporary keychain"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+echo "$BUILD_CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$P12_PASSWORD" \
+    -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+# shellcheck disable=SC2046
+security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
+
+IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+    | awk -F'"' '/Developer ID Application/{print $2; exit}')"
+[ -n "$IDENTITY" ] || { echo "ERROR: no Developer ID Application identity in cert" >&2; exit 1; }
+echo "    identity: $IDENTITY"
+
+echo "==> swift build + bundle"
+swift build -c release
+BIN="$(swift build -c release --show-bin-path)"
+APP="$BIN/proctap-helper.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp "$BIN/proctap-helper" "$APP/Contents/MacOS/proctap-helper"
+cp "$INFO_PLIST" "$APP/Contents/Info.plist"
+
+echo "==> codesign (Developer ID, hardened runtime)"
+codesign --force --sign "$IDENTITY" --keychain "$KEYCHAIN" \
+    --entitlements "$ENTITLEMENTS" --options runtime --timestamp "$APP"
+codesign --verify --strict --verbose=2 "$APP"
+
+echo "==> notarize + staple"
+KEYP8="$RUNNER_TEMP/AuthKey.p8"
+echo "$ASC_KEY_P8_BASE64" | base64 --decode > "$KEYP8"
+ZIP="$RUNNER_TEMP/proctap-helper.zip"
+ditto -c -k --keepParent "$APP" "$ZIP"
+xcrun notarytool submit "$ZIP" \
+    --key "$KEYP8" --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID" --wait
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+
+echo "==> stage into package bin/ for wheel packaging"
+DEST="../../bin/proctap-helper.app"
+rm -rf "$DEST"
+mkdir -p "../../bin"
+cp -R "$APP" "$DEST"
+
+echo "Done: signed + notarized $DEST"

--- a/src/proctap/swift/proctap-helper/proctap-helper.entitlements
+++ b/src/proctap/swift/proctap-helper/proctap-helper.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Required for Core Audio Process Tap / audio capture under the hardened runtime. -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src/proctap/swift/proctap-helper/sign_with_p12.sh
+++ b/src/proctap/swift/proctap-helper/sign_with_p12.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Sign the already-built proctap-helper.app using a Developer ID identity stored
+# in a .p12 (PKCS#12) file. This works from a non-interactive session (where the
+# login keychain's private key is inaccessible -> errSecInternalComponent) by
+# importing the .p12 into a throwaway keychain, signing, then deleting it.
+#
+# The .p12 password is read from a FILE (never passed on the command line or
+# printed) so it does not leak into shell history / logs.
+#
+# Usage:
+#   ./sign_with_p12.sh <path-to.p12> <path-to-password-file>
+#
+# Create the password file privately, e.g. in your own Terminal:
+#   printf '%s' 'YOUR_P12_PASSWORD' > ~/.proctap_p12_pw && chmod 600 ~/.proctap_p12_pw
+#
+# The .p12 must contain the "Developer ID Application" certificate AND its
+# private key (export the identity from Keychain Access as .p12).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+P12_PATH="${1:?usage: sign_with_p12.sh <p12> <password-file>}"
+PW_FILE="${2:?usage: sign_with_p12.sh <p12> <password-file>}"
+ENTITLEMENTS="proctap-helper.entitlements"
+
+[[ -f "$P12_PATH" ]] || { echo "ERROR: .p12 not found: $P12_PATH" >&2; exit 1; }
+[[ -f "$PW_FILE" ]]  || { echo "ERROR: password file not found: $PW_FILE" >&2; exit 1; }
+
+APP_BUNDLE="$(swift build -c release --show-bin-path)/proctap-helper.app"
+[[ -d "$APP_BUNDLE" ]] || { echo "ERROR: build first (./build.sh --no-sign): $APP_BUNDLE" >&2; exit 1; }
+
+P12_PW="$(cat "$PW_FILE")"
+
+# Throwaway keychain (auto-cleaned on exit).
+TMPDIR_KC="$(mktemp -d)"
+KEYCHAIN="${TMPDIR_KC}/proctap-signing.keychain-db"
+KC_PW="proctap-$$-temp"
+
+cleanup() {
+    security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+    rm -rf "$TMPDIR_KC"
+}
+trap cleanup EXIT
+
+echo "==> Creating temporary keychain"
+security create-keychain -p "$KC_PW" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KC_PW" "$KEYCHAIN"
+
+echo "==> Importing .p12"
+security import "$P12_PATH" -k "$KEYCHAIN" -P "$P12_PW" \
+    -T /usr/bin/codesign -T /usr/bin/security
+# Allow codesign to use the key without an interactive prompt.
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PW" "$KEYCHAIN" >/dev/null
+
+# Prepend our keychain to the search list so codesign can find the identity.
+ORIG_KEYCHAINS="$(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')"
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$KEYCHAIN" $ORIG_KEYCHAINS
+
+restore_keychains() {
+    # shellcheck disable=SC2086
+    security list-keychains -d user -s $ORIG_KEYCHAINS 2>/dev/null || true
+    cleanup
+}
+trap restore_keychains EXIT
+
+IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+    | awk -F'"' '/Developer ID Application/{print $2; exit}')"
+[[ -n "$IDENTITY" ]] || { echo "ERROR: no Developer ID Application identity in .p12" >&2; exit 1; }
+
+echo "==> Signing with: $IDENTITY"
+codesign --force \
+         --sign "$IDENTITY" \
+         --keychain "$KEYCHAIN" \
+         --entitlements "$ENTITLEMENTS" \
+         --options runtime \
+         --timestamp \
+         "$APP_BUNDLE"
+
+echo "==> Verifying"
+codesign --verify --strict --verbose=2 "$APP_BUNDLE"
+codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 | grep -E "Identifier|Authority|TeamIdentifier|Runtime" || true
+
+echo ""
+echo "Signed: $APP_BUNDLE"

--- a/tests/test_macos_processtap.py
+++ b/tests/test_macos_processtap.py
@@ -1,0 +1,43 @@
+"""
+Tests for the macOS Process Tap backend selection/availability (#57).
+
+These are platform-safe: the actual capture path needs macOS 14.4+, the signed
+helper app and Screen Recording permission, so it is only smoke-checked here.
+"""
+
+import platform
+
+import pytest
+
+from proctap.backends import macos_processtap as mpt
+
+
+class TestAvailability:
+    def test_not_available_off_macos(self):
+        if platform.system() == "Darwin":
+            pytest.skip("macOS-specific negative test")
+        assert mpt.is_available() is False
+
+    def test_find_app_returns_path_or_none(self):
+        # Never raises; returns a Path to a .app or None.
+        result = mpt.find_processtap_app()
+        assert result is None or result.name.endswith(".app")
+
+
+class TestTapConstants:
+    def test_tap_native_format(self):
+        # The helper negotiates 44.1kHz/2ch/float32; the backend converts to std.
+        assert mpt.TAP_SAMPLE_RATE == 44100
+        assert mpt.TAP_CHANNELS == 2
+        assert mpt.TAP_SAMPLE_WIDTH == 4
+
+
+@pytest.mark.skipif(not mpt.is_available(), reason="requires built helper on macOS")
+class TestBackendConstruction:
+    def test_get_format_is_standard(self):
+        b = mpt.ProcessTapBackend(pid=1)
+        fmt = b.get_format()
+        assert fmt["sample_rate"] == 48000
+        assert fmt["channels"] == 2
+        assert fmt["bits_per_sample"] == 32
+        assert fmt["sample_format"] == "float32"


### PR DESCRIPTION
Implements #57: a **PID-based** macOS audio-capture backend via the Core Audio Process Tap API — matching the Windows (WASAPI) / Linux (PipeWire) per-process semantics, instead of the bundleID-based ScreenCaptureKit backend.

**Verified on macOS 15.6 / Apple Silicon**, with a Developer ID signature and **no SIP/AMFI disabling**: `ProcessAudioCapture(pid=chrome_audio_service)` captures real YouTube audio (RMS ~0.08, 96%+ non-zero).

## The archive was "blocked only by signing" — that was wrong

The archived helper (`archive/apple-silicon-investigation-20251120/`) still failed after signing. Four real bugs plus a permission requirement were the actual blockers:

1. **Wrong selector FourCC** `'pid2'` → `'id2p'` (`kAudioHardwarePropertyTranslatePIDToProcessObject`). This — not AMFI — was the `status=2003332927` (`'wat?'`) failure.
2. **Fragile ObjC-runtime `CATapDescription`** construction → bus error on macOS 15. Now uses the public `CATapDescription(stereoMixdownOfProcesses:)` API (macOS 14.4+).
3. **Swift 6 concurrency trap**: the IOProc block inherited `@main`'s MainActor isolation → `_dispatch_assert_queue_fail` SIGTRAP. Fixed with Swift 5 language mode.
4. **Aggregate/tap wiring**: use the tap's actual `kAudioTapPropertyUID`, correct default-output UID read, `tapautostart`.
5. **Silence root cause**: the tapped audio *content* is gated by **Screen Recording permission granted to the responsible process**. Executing the helper as a child of Python inherits the parent's TCC identity and yields silence; launching via LaunchServices (`open`) makes it its own responsible process and (once Screen Recording is enabled for it) delivers real audio.

## What's in this PR

- **`swift/proctap-helper/`** — the revived helper: `main.swift`, `Package.swift` (Swift 5 mode), `Info.plist`, entitlements, `build.sh`, `sign_with_p12.sh` (headless .p12 signing), README.
- **`backends/macos_processtap.py`** — `ProcessTapBackend`: launches the helper via `open` (own TCC identity), streams PCM back over a FIFO, converts the tap's 44.1kHz/2ch/float32 to the standard 48kHz/2ch/float32. Backend selection prefers it when the signed app is present, else ScreenCaptureKit → PyObjC.
- **Release CI** — `ci_sign_notarize.sh` + steps in `publish-pypi.yml` / `release-testpypi.yml` that build + Developer ID sign + notarize + staple the `.app` and stage it into the wheel; self-skips without signing secrets. `setup.py`/`MANIFEST.in` package it. Secrets documented in `docs/macos-processtap-signing.md`.
- Platform-safe tests for backend availability/format.

## Runtime requirement

Each user grants **Screen Recording** to `proctap-helper` once (System Settings › Privacy & Security › Screen Recording); the backend registers it there on first launch.

## Notes / follow-ups

- CI signing/notarization steps mirror the maintainer's proven Developer ID recipe but need the secrets configured and a first real-tag run to shake out.
- The 44.1→48 kHz per-chunk resample falls back to scipy FFT at chunk boundaries (noisy log, works); worth smoothing later.
- Helper still prints verbose stderr diagnostics; could be gated behind a flag for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)